### PR TITLE
fix(lsock): correct mmap failure check in CircleBuf constructor

### DIFF
--- a/observe/lsock.cpp
+++ b/observe/lsock.cpp
@@ -802,7 +802,7 @@ class CircleBuf
 			-1,
 			0
 		);
-		if (addr1 == MAP_FAILED)
+		if (addr_map == MAP_FAILED)
 		{
 			pr_error("mmap: %s\n", strerror(errno));
 			goto err;


### PR DESCRIPTION
CircleBuf constructor checks addr1 instead of addr_map for MAP_FAILED, causing mmap failures to go undetected and potentially crash later in shmat or buffer operations.