### PR TITLE
fix(trace-file): close iter_fd on open() failure in update_filter()

### DIFF
--- a/observe/trace-file.cpp
+++ b/observe/trace-file.cpp
@@ -1171,6 +1171,7 @@ static int update_filter(int filter_fd)
 	if (target_fd < 0)
 	{
 		pr_error("open err: %s: %s\n", rule.path, strerror(errno));
+		close(iter_fd);
 		return errno;
 	}
 


### PR DESCRIPTION
When open(rule.path) fails in update_filter(), the function returns without closing iter_fd obtained from bpf_iter_create(), causing a file descriptor leak. Other error paths (fstat, malloc) in the same function already close iter_fd correctly.