### PR TITLE
fix: bound spinlock stats growth

### DIFF
--- a/observe/spinlock_ob.c
+++ b/observe/spinlock_ob.c
@@ -802,14 +802,24 @@ static void print_hld_task(struct stack_stat *ss)
 
 static int print_stats(struct ksyms *ksyms, int stacks, int stat_map)
 {
+	struct bpf_map_info map_info = {};
 	struct stack_stat **stats, *ss;
+	uint32_t map_info_len = sizeof(map_info);
 	size_t stat_idx = 0;
 	size_t stats_sz = 1;
+	size_t stats_cap;
 	uint32_t lookup_key = 0;
 	uint32_t stack_id;
 	int ret, i;
 	int nr_stack_entries;
 
+	ret = bpf_map_get_info_by_fd(stat_map, &map_info, &map_info_len);
+	if (ret || !map_info.max_entries)
+	{
+		warn("failed to get stat map info\n");
+		return -1;
+	}
+	stats_cap = map_info.max_entries;
 	stats = (struct stack_stat **)calloc(stats_sz, sizeof(void *));
 	if (!stats)
 	{
@@ -823,7 +833,16 @@ static int print_stats(struct ksyms *ksyms, int stacks, int stat_map)
 		{
 			struct stack_stat **tmp;
 
+			if (stats_sz == stats_cap)
+			{
+				warn("stat map entry count exceeds max_entries %zu\n", stats_cap);
+				goto free_stats;
+			}
 			stats_sz *= 2;
+			if (stats_sz > stats_cap)
+			{
+				stats_sz = stats_cap;
+			}
 			tmp = (struct stack_stat **)
 				libbpf_reallocarray(stats, stats_sz, sizeof(void *));
 			if (!tmp)

--- a/observe/spinlock_ob.c
+++ b/observe/spinlock_ob.c
@@ -821,20 +821,23 @@ static int print_stats(struct ksyms *ksyms, int stacks, int stat_map)
 	{
 		if (stat_idx == stats_sz)
 		{
+			struct stack_stat **tmp;
+
 			stats_sz *= 2;
-			stats = (struct stack_stat **)
+			tmp = (struct stack_stat **)
 				libbpf_reallocarray(stats, stats_sz, sizeof(void *));
-			if (!stats)
+			if (!tmp)
 			{
 				warn("Out of memory\n");
-				return -1;
+				goto free_stats;
 			}
+			stats = tmp;
 		}
 		ss = (struct stack_stat *)malloc(sizeof(struct stack_stat));
 		if (!ss)
 		{
 			warn("Out of memory\n");
-			return -1;
+			goto free_stats;
 		}
 
 		lookup_key = ss->stack_id = stack_id;
@@ -908,6 +911,12 @@ static int print_stats(struct ksyms *ksyms, int stacks, int stat_map)
 	free(stats);
 
 	return 0;
+
+free_stats:
+	for (i = 0; i < (int)stat_idx; i++)
+		free(stats[i]);
+	free(stats);
+	return -1;
 }
 
 static volatile bool exiting;

--- a/observe/urblat.c
+++ b/observe/urblat.c
@@ -642,6 +642,8 @@ int main(int argc, char **argv)
 		if (bpf_map_update_elem(cg_map_fd, &idx, &cgfd, BPF_ANY))
 		{
 			fprintf(stderr, "Failed adding target cgroup to map");
+			close(cgfd);
+			cgfd = -1;
 			goto cleanup;
 		}
 	}


### PR DESCRIPTION
  ## Summary

  - Bound `spinlock_ob` stats array growth by `stat_map.max_entries`
  - Restore cleanup path for allocated `stack_stat` entries on allocation failure
  - Prevent `DataMap` from overwriting entries during one update cycle when too many process records are
  collected
  - Return `-ENOBUFS` when the data-map capacity is exceeded

  ## Verification

  - `make bpf`
  - `make -C observe all`
  - `make -C so all`
  - `git diff --check`
  
  ## Issues

  Fixes #60 
