### PR TITLE
fix: enable_write_trace checks FD_WRITE instead of FD_READ

### DIFF
--- a/observe/peek-fd.cpp
+++ b/observe/peek-fd.cpp
@@ -252,7 +252,7 @@ static void enable_read_trace(void)
 
 static void enable_write_trace(void)
 {
-	if (!(rule.rw & FD_READ))
+	if (!(rule.rw & FD_WRITE))
 	{
 		return;
 	}


### PR DESCRIPTION
enable_write_trace() at observe/peek-fd.cpp:255 contained a copy-paste error: it checked rule.rw & FD_READ instead of FD_WRITE. This caused the -w flag to have no effect, and -r to incorrectly enable write tracing probes.

Fixes: write trace never enabled, read trace enabled wrong probes