### PR TITLE
fix(build): use atomic temp file for .skel.h generation

### DIFF
--- a/filter/Makefile
+++ b/filter/Makefile
@@ -61,14 +61,15 @@ $(BUILD_DIR)/%.o: %.c $(BUILD_DIR)/%.skel.h | $(BUILD_DIR)
 	$(CC) $(CFLAGS) -c $< -o $@
 
 $(BUILD_DIR)/%.skel.h: $(BPF_DIR)/%.bpf.o | $(BUILD_DIR)
-	bpftool gen skeleton $< > $@
-	python3 $(PROJ_ROOT)/script/patch_skel.py --obj-dir $(BPF_DIR_PATCH) $@
+	bpftool gen skeleton $< > $(dir $@).tmp.$$$$.$(notdir $@) && \
+	python3 $(PROJ_ROOT)/script/patch_skel.py --obj-dir $(BPF_DIR_PATCH) $(dir $@).tmp.$$$$.$(notdir $@) && \
+	mv $(dir $@).tmp.$$$$.$(notdir $@) $@
 
 $(BUILD_DIR)/log.o: $(PROJ_ROOT)/so/log.cpp | $(BUILD_DIR)
 	$(CXX) $(CXXFLAGS) -c $< -o $@
 
 clean:
-	rm -f $(BUILD_DIR)/*.o $(BUILD_DIR)/*.d $(TARGETs)
+	rm -f $(BUILD_DIR)/*.o $(BUILD_DIR)/*.d $(TARGETs) $(BUILD_DIR)/.tmp.*.skel.h
 
 distclean:
 	rm -rf $(BUILD_DIR)

--- a/observe/Makefile
+++ b/observe/Makefile
@@ -71,11 +71,12 @@ $(BUILD_DIR)/%.o: $(PROJ_ROOT)/so/%.cpp | $(BUILD_DIR)
 	$(CXX) $(CXXFLAGS) -c $< -o $@
 
 $(BUILD_DIR)/%.skel.h: $(BPF_DIR)/%.bpf.o | $(BUILD_DIR)
-	bpftool gen skeleton $< > $@
-	python3 $(PROJ_ROOT)/script/patch_skel.py --obj-dir $(BPF_DIR_PATCH) $@
+	bpftool gen skeleton $< > $(dir $@).tmp.$$$$.$(notdir $@) && \
+	python3 $(PROJ_ROOT)/script/patch_skel.py --obj-dir $(BPF_DIR_PATCH) $(dir $@).tmp.$$$$.$(notdir $@) && \
+	mv $(dir $@).tmp.$$$$.$(notdir $@) $@
 
 clean:
-	rm -f $(BUILD_DIR)/*.o $(BUILD_DIR)/*.d $(TARGETs)
+	rm -f $(BUILD_DIR)/*.o $(BUILD_DIR)/*.d $(TARGETs) $(BUILD_DIR)/.tmp.*.skel.h
 
 distclean:
 	rm -rf $(BUILD_DIR)

--- a/policy/Makefile
+++ b/policy/Makefile
@@ -48,11 +48,12 @@ $(BUILD_DIR)/%.o: $(PROJ_ROOT)/so/%.cpp | $(BUILD_DIR)
 	$(CXX) $(CXXFLAGS) -c $< -o $@
 
 $(BUILD_DIR)/%.skel.h: $(BPF_DIR)/%.bpf.o | $(BUILD_DIR)
-	bpftool gen skeleton $< > $@
-	python3 $(PROJ_ROOT)/script/patch_skel.py --obj-dir $(BPF_DIR_PATCH) $@
+	bpftool gen skeleton $< > $(dir $@).tmp.$$$$.$(notdir $@) && \
+	python3 $(PROJ_ROOT)/script/patch_skel.py --obj-dir $(BPF_DIR_PATCH) $(dir $@).tmp.$$$$.$(notdir $@) && \
+	mv $(dir $@).tmp.$$$$.$(notdir $@) $@
 
 clean:
-	rm -f $(BUILD_DIR)/*.skel.h $(BUILD_DIR)/*.o $(BUILD_DIR)/*.d $(TARGETs)
+	rm -f $(BUILD_DIR)/*.skel.h $(BUILD_DIR)/*.o $(BUILD_DIR)/*.d $(TARGETs) $(BUILD_DIR)/.tmp.*.skel.h
 
 distclean:
 	rm -rf $(BUILD_DIR)

--- a/script/patch_skel.py
+++ b/script/patch_skel.py
@@ -275,6 +275,7 @@ def patch_header(header_path: str, dry_run: bool = False, obj_dir: str | None = 
     # Infer the corresponding object file path and ensure it exists
     if obj_dir:
         stem = os.path.basename(header_path)[:-len('.skel.h')]
+        stem = re.sub(r'^\.tmp\.\d+\.', '', stem)
         obj_path = os.path.join(obj_dir, stem + '.bpf.o')
     else:
         obj_path = header_path[:-len('.skel.h')] + '.bpf.o'


### PR DESCRIPTION
Replace direct '>' redirection with '.tmp + mv' pattern to prevent truncated/corrupted .skel.h files when bpftool fails under parallel build.  Chain commands with && so patch_skel.py and mv only run on success.