### PR TITLE
build: fix parallel build races in skel.h generation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -23,7 +23,8 @@ all: $(TARGETs)
 
 demo test: so
 bpf: $(if $(filter 1,$(USE_SUBMODULE)),bpf.gitsubmodule)
-observe filter policy so: bpf
+observe filter policy: bpf tools
+so: observe filter policy
 
 $(TARGETs):
 	$(MAKE) -C $@

--- a/filter/Makefile
+++ b/filter/Makefile
@@ -69,9 +69,8 @@ $(BPF_PREPROCESS):
 
 $(BUILD_DIR)/%.skel.h: $(BPF_DIR)/%.bpf.o $(BPF_PREPROCESS) | $(BUILD_DIR)
 	$(BPF_PREPROCESS) $< $(BUILD_DIR)/$*.bpf.o
-	bpftool gen skeleton $(BUILD_DIR)/$*.bpf.o > $(dir $@).tmp.$$$$.$(notdir $@) && \
-	python3 $(PROJ_ROOT)/script/patch_skel.py --obj-dir $(BUILD_DIR) $(dir $@).tmp.$$$$.$(notdir $@) && \
-	mv $(dir $@).tmp.$$$$.$(notdir $@) $@
+	bpftool gen skeleton $(BUILD_DIR)/$*.bpf.o > $@
+	python3 $(PROJ_ROOT)/script/patch_skel.py --obj-dir $(BUILD_DIR) $@
 
 $(BUILD_DIR)/log.o: $(PROJ_ROOT)/so/log.cpp | $(BUILD_DIR)
 	$(CXX) $(CXXFLAGS) -c $< -o $@

--- a/observe/Makefile
+++ b/observe/Makefile
@@ -78,9 +78,8 @@ $(BPF_PREPROCESS):
 
 $(BUILD_DIR)/%.skel.h: $(BPF_DIR)/%.bpf.o $(BPF_PREPROCESS) | $(BUILD_DIR)
 	$(BPF_PREPROCESS) $< $(BUILD_DIR)/$*.bpf.o
-	bpftool gen skeleton $(BUILD_DIR)/$*.bpf.o > $(dir $@).tmp.$$$$.$(notdir $@) && \
-	python3 $(PROJ_ROOT)/script/patch_skel.py --obj-dir $(BUILD_DIR) $(dir $@).tmp.$$$$.$(notdir $@) && \
-	mv $(dir $@).tmp.$$$$.$(notdir $@) $@
+	bpftool gen skeleton $(BUILD_DIR)/$*.bpf.o > $@
+	python3 $(PROJ_ROOT)/script/patch_skel.py --obj-dir $(BUILD_DIR) $@
 
 clean:
 	rm -f $(BUILD_DIR)/*.o $(BUILD_DIR)/*.d $(TARGETs) $(BUILD_DIR)/.tmp.*.skel.h

--- a/policy/Makefile
+++ b/policy/Makefile
@@ -56,9 +56,8 @@ $(BPF_PREPROCESS):
 
 $(BUILD_DIR)/%.skel.h: $(BPF_DIR)/%.bpf.o $(BPF_PREPROCESS) | $(BUILD_DIR)
 	$(BPF_PREPROCESS) $< $(BUILD_DIR)/$*.bpf.o
-	bpftool gen skeleton $(BUILD_DIR)/$*.bpf.o > $(dir $@).tmp.$$$$.$(notdir $@) && \
-	python3 $(PROJ_ROOT)/script/patch_skel.py --obj-dir $(BUILD_DIR) $(dir $@).tmp.$$$$.$(notdir $@) && \
-	mv $(dir $@).tmp.$$$$.$(notdir $@) $@
+	bpftool gen skeleton $(BUILD_DIR)/$*.bpf.o > $@
+	python3 $(PROJ_ROOT)/script/patch_skel.py $@
 
 clean:
 	rm -f $(BUILD_DIR)/*.skel.h $(BUILD_DIR)/*.o $(BUILD_DIR)/*.d $(TARGETs) $(BUILD_DIR)/.tmp.*.skel.h

--- a/script/gen-source-pkg.sh
+++ b/script/gen-source-pkg.sh
@@ -91,8 +91,8 @@ echo -e "${YELLOW}Collecting main repo source files...${NC}"
 cd "${PROJECT_ROOT}"
 git ls-files --cached | while IFS= read -r f; do
     case "$f" in
-        bpf|bpf/*|googletest|googletest/*|test/*|tools/*|.gitmodules|*.spec)
-            # bpf/ handled separately; googletest/test/tools not needed for RPM
+        bpf|bpf/*|googletest|googletest/*|test/*|.gitmodules|*.spec)
+            # bpf/ handled separately; googletest/test not needed for RPM
             continue
             ;;
         *)
@@ -226,8 +226,12 @@ if [ -f bpf/build/include/vmlinux.h ]; then
     VMLINUX_OVERRIDE="VMLINUX=bpf/build/include/vmlinux.h"
 fi
 
+# Build extern-prep once to avoid parallel build race across modules
+make -C tools extern-prep
+
 make %{?_smp_mflags} USE_SUBMODULE=0                     \\
     \${VMLINUX_OVERRIDE}                                   \\
+    BPF_PREPROCESS=\$(pwd)/build/tools/extern-prep         \\
     KHEADERS_DIR="\${KHEADERS_DIR}"                       \\
     bpf                                                  \\
     observe BPF_DIR_PATCH=/usr/lib/dkapture               \\

--- a/script/patch_skel.py
+++ b/script/patch_skel.py
@@ -275,7 +275,7 @@ def patch_header(header_path: str, dry_run: bool = False, obj_dir: str | None = 
     # Infer the corresponding object file path and ensure it exists
     if obj_dir:
         stem = os.path.basename(header_path)[:-len('.skel.h')]
-        stem = re.sub(r'^\.tmp\.\d+\.', '', stem)
+        stem = re.sub(r'^\.tmp\.(\d+\.)?', '', stem)
         obj_path = os.path.join(obj_dir, stem + '.bpf.o')
     else:
         obj_path = header_path[:-len('.skel.h')] + '.bpf.o'


### PR DESCRIPTION
- Fix top-level Makefile: so target now depends on observe/filter/policy, eliminating parallel builds of shared .skel.h and extern-prep outputs
- observe/filter/policy now depend on tools, ensuring extern-prep is built before BPF preprocessing starts
- Simplify .skel.h recipes: remove PID-based temp file uniquification, use simple .tmp prefix with mv atomic replacement
- patch_skel.py: extend .tmp prefix stripping to handle both PID and non-PID patterns