### PR TITLE
refactor(lsof): migrate lsof to DKapture and add directory/fs filters

### DIFF
--- a/observe/Makefile
+++ b/observe/Makefile
@@ -7,7 +7,10 @@ MODULE := $(notdir $(CURDIR))
 BUILD_DIR := $(PROJ_ROOT)/build/$(MODULE)
 C_SRC = $(shell ls *.c 2>/dev/null)
 CXX_SRC = $(shell ls *.cpp 2>/dev/null)
-TARGETs = $(C_SRC:%.c=$(BUILD_DIR)/%) $(CXX_SRC:%.cpp=$(BUILD_DIR)/%)
+TARGET_NAMES = $(C_SRC:%.c=%) $(CXX_SRC:%.cpp=%)
+TARGETs = $(addprefix $(BUILD_DIR)/,$(TARGET_NAMES))
+NO_SKEL_CXX_TARGETS = ps proc-info lsof
+DKAPTURE_TARGETS = ps proc-info lsof
 BPF_TARGET_ARCH := $(shell uname -m)
 ifeq ($(BPF_TARGET_ARCH), loongarch64)
 	BPF_TARGET_ARCH := loongarch
@@ -44,7 +47,7 @@ CXXFLAGS = $(CFLAGS)
 CC = gcc
 CXX = g++
 
-.PHONY: all clean
+.PHONY: all clean $(TARGET_NAMES)
 # 注明不要删除的中间文件
 .SECONDARY:
 .SUFFIXES:
@@ -53,16 +56,27 @@ CXX = g++
 
 all: $(TARGETs)
 
+$(TARGET_NAMES): %: $(BUILD_DIR)/%
+
+$(PROJ_ROOT)/build/so/libdkapture.so:
+	$(MAKE) -C $(PROJ_ROOT)/so
+
 $(BUILD_DIR):
 	@mkdir -p $@
 
 SO_NAMES = bpf-linker pin-registry map-resolver btf-preprocessor
 SO_OBJS = $(addprefix $(BUILD_DIR)/,$(addsuffix .o,$(SO_NAMES)))
 
+$(addprefix $(BUILD_DIR)/,$(DKAPTURE_TARGETS)): LDFLAGS += -L$(PROJ_ROOT)/build/so -ldkapture -Wl,-rpath,$(PROJ_ROOT)/build/so
+$(addprefix $(BUILD_DIR)/,$(DKAPTURE_TARGETS)): $(PROJ_ROOT)/build/so/libdkapture.so
+
 $(BUILD_DIR)/%: $(BUILD_DIR)/%.o $(BUILD_DIR)/log.o $(SO_OBJS)
 	$(CXX) $(LDFLAGS) $^ -o $@
 
 $(BUILD_DIR)/%.o: %.cpp $(BUILD_DIR)/%.skel.h | $(BUILD_DIR)
+	$(CXX) $(CXXFLAGS) -c $< -o $@
+
+$(addprefix $(BUILD_DIR)/,$(addsuffix .o,$(NO_SKEL_CXX_TARGETS))): $(BUILD_DIR)/%.o: %.cpp | $(BUILD_DIR)
 	$(CXX) $(CXXFLAGS) -c $< -o $@
 
 $(BUILD_DIR)/%.o: %.c $(BUILD_DIR)/%.skel.h | $(BUILD_DIR)
@@ -75,6 +89,9 @@ BPF_PREPROCESS = $(PROJ_ROOT)/build/tools/extern-prep
 
 $(BPF_PREPROCESS):
 	$(MAKE) -C $(PROJ_ROOT)/tools extern-prep
+
+$(BPF_DIR)/%.bpf.o:
+	$(MAKE) -C $(PROJ_ROOT)/bpf/$(MODULE) PROJ_ROOT=$(PROJ_ROOT)/bpf $(BPF_DIR)/$*.bpf.o
 
 $(BUILD_DIR)/%.skel.h: $(BPF_DIR)/%.bpf.o $(BPF_PREPROCESS) | $(BUILD_DIR)
 	$(BPF_PREPROCESS) $< $(BUILD_DIR)/$*.bpf.o

--- a/observe/lsof.cpp
+++ b/observe/lsof.cpp
@@ -2,76 +2,80 @@
 //
 // SPDX-License-Identifier: LGPL-2.1
 
-#include <stdio.h>
-#include <assert.h>
-#include <fcntl.h>
-#include <unistd.h>
-#include <string.h>
-#include <time.h>
-#include <sys/syscall.h>
-#include <bpf/bpf.h>
+#include <argp.h>
+#include <dirent.h>
+#include <errno.h>
 #include <limits.h>
-#include <getopt.h>
-#include <string>
-#include <signal.h>
-#include <iostream>
-#include <thread>
-#include <chrono>
-#include <atomic>
-#include <vector>
-#include <algorithm>
-#include <pthread.h>
+#include <sys/stat.h>
+#include <unistd.h>
+
+#include <cstring>
 #include <map>
-#include <sys/sysmacros.h> // 添加这个头文件用于设备号操作
+#include <memory>
+#include <set>
+#include <string>
+#include <vector>
 
-#include "lsof.skel.h"
-#include "com.h"
-#include "jhash.h"
+#include "dkapture.h"
 
-#define PATH_MAX 4096
-
-// 添加设备号转换函数，参考frtp
-static inline uint32_t dev_old2new(dev_t old)
+struct FileKey
 {
-	uint32_t major = gnu_dev_major(old);
-	uint32_t minor = gnu_dev_minor(old);
-	return ((major & 0xfff) << 20) | (minor & 0xfffff);
-}
+	dev_t dev;
+	unsigned long inode;
 
-union Rule
-{
-	char path[PATH_MAX];
-	struct
+	bool operator<(const FileKey &other) const
 	{
-		u64 not_inode; // used for judging whether it's inode filter
-		u64 inode;
-		dev_t dev; // 设备号
-	};
-} rule;
-
-struct BpfData
-{
-	uid_t uid;
-	pid_t pid;
-	int fd;
-	char comm[16];
+		if (dev != other.dev)
+		{
+			return dev < other.dev;
+		}
+		return inode < other.inode;
+	}
 };
 
-static lsof_bpf *obj;
-static int log_map_fd;
-struct ring_buffer *rb = NULL;
-static int filter_fd;
-static pthread_t t1;
-static int iter_fd;
-static std::atomic<bool> exit_flag(false);
-static std::map<pid_t, std::vector<struct BpfData>> log_stat;
+enum QueryMode
+{
+	QUERY_NONE,
+	QUERY_SINGLE_OBJECT,
+	QUERY_FS_DEV,
+	QUERY_DIR_CHILDREN,
+};
+
+struct Rule
+{
+	char path[PATH_MAX];
+	char dir_path[PATH_MAX];
+	unsigned long long inode;
+	dev_t dev;
+	QueryMode mode;
+} rule = {
+	.path = {0},
+	.dir_path = {0},
+	.inode = 0,
+	.dev = 0,
+	.mode = QUERY_NONE,
+};
+
+struct LsofEntry
+{
+	uid_t uid = 0;
+	pid_t pid = 0;
+	std::string comm;
+	std::vector<int> fds;
+	size_t vma_cnt = 0;
+};
+
+static std::map<pid_t, LsofEntry> log_stat;
+static std::map<pid_t, uid_t> uid_stat;
+static std::set<FileKey> dir_children;
 
 static struct option lopts[] = {
-	{"path",	 required_argument, 0, 'p'},
-	{"dev",	required_argument, 0, 'd'},
+	{"path", required_argument, 0, 'p'},
+	{"dev", required_argument, 0, 'd'},
 	{"inode", required_argument, 0, 'i'},
-	{"help",	 no_argument,		  0, 'h'},
-	{0,		0,				 0, 0  }
+	{"fs-dev", required_argument, 0, 1000},
+	{"help", no_argument, 0, 'h'},
+	{0, 0, 0, 0},
 };
 
 struct HelpMsg
@@ -81,111 +85,353 @@ struct HelpMsg
 };
 
 static HelpMsg help_msg[] = {
-	{"[path]",  "path of the file to watch on\n"					   },
+	{"[path]",
+	 "path of the target object.\n"
+	 "\tThe path is resolved by stat(2) and matched by (dev,inode).\n"
+	 "\tThis queries one filesystem object only.\n"},
 	{"[dev]",
 	 "the device number of filesystem to which the inode belong.\n"
-	 "\tyou can get the dev by running command 'stat -c %d <file>'\n"
-	}, // 更新帮助信息
-	{"[inode]", "inode of the file to watch on\n"					 },
-	{"",		 "print this help message\n"							},
+	 "\tyou can get the dev by running command 'stat -c %d <file>'\n"},
+	{"[inode]", "inode of the file to watch on\n"},
+	{"[dev]",
+	 "match all file objects on the specified filesystem device.\n"},
+	{"", "print this help message\n"},
 };
 
-void Usage(const char *arg0)
+static void Usage(const char *arg0)
 {
 	printf("Usage: %s [option]\n", arg0);
 	printf("  To query who are occupying the specified file.\n\n");
+	printf("Query modes:\n");
+	printf("  -p <path>      match one filesystem object by stat(2)\n");
+	printf("  -d <dev> -i <inode>\n");
+	printf("                 match one filesystem object by (dev,inode)\n");
+	printf("      --fs-dev <dev>\n");
+	printf("                 match all objects on one filesystem device\n");
+	printf("  +d <dir>       match direct children of one directory only\n\n");
 	printf("Options:\n");
 	for (int i = 0; lopts[i].name; i++)
 	{
-		printf(
-			"  -%c, --%s %s\n\t%s\n",
-			lopts[i].val,
-			lopts[i].name,
-			help_msg[i].argparam,
-			help_msg[i].msg
-		);
+		if (lopts[i].val > 0 && lopts[i].val < 128)
+		{
+			printf(
+				"  -%c, --%s %s\n\t%s\n",
+				lopts[i].val,
+				lopts[i].name,
+				help_msg[i].argparam,
+				help_msg[i].msg
+			);
+		}
+		else
+		{
+			printf(
+				"      --%s %s\n\t%s\n",
+				lopts[i].name,
+				help_msg[i].argparam,
+				help_msg[i].msg
+			);
+		}
 	}
+	printf("  +d [dir]\n\tmatch direct children of one directory only\n");
 }
 
-std::string long_opt2short_opt(const option lopts[])
+static std::string long_opt2short_opt(const option lopts[])
 {
-	std::string sopts = "";
+	std::string sopts;
 	for (int i = 0; lopts[i].name; i++)
 	{
-		sopts += lopts[i].val;
-		switch (lopts[i].has_arg)
+		if (lopts[i].val > 0 && lopts[i].val < 128)
 		{
-		case no_argument:
-			break;
-		case required_argument:
-			sopts += ":";
-			break;
-		case optional_argument:
-			sopts += "::";
-			break;
-		default:
-			DIE("Code internal bug!!!\n");
-			abort();
+			sopts += static_cast<char>(lopts[i].val);
+			switch (lopts[i].has_arg)
+			{
+			case no_argument:
+				break;
+			case required_argument:
+				sopts += ":";
+				break;
+			case optional_argument:
+				sopts += "::";
+				break;
+			default:
+				fprintf(stderr, "Code internal bug\n");
+				abort();
+			}
 		}
 	}
 	return sopts;
 }
 
-void parse_args(int argc, char *args[])
+static int resolve_path_rule(void)
+{
+	struct stat st = {};
+	if (stat(rule.path, &st) != 0)
+	{
+		return -errno;
+	}
+
+	rule.dev = st.st_dev;
+	rule.inode = st.st_ino;
+	return 0;
+}
+
+static int collect_dir_children(const char *path)
+{
+	struct stat st = {};
+	if (stat(path, &st) != 0)
+	{
+		return -errno;
+	}
+	if (!S_ISDIR(st.st_mode))
+	{
+		return -ENOTDIR;
+	}
+
+	DIR *dir = opendir(path);
+	if (!dir)
+	{
+		return -errno;
+	}
+
+	dir_children.clear();
+	const int dfd = dirfd(dir);
+	struct dirent *ent;
+	while ((ent = readdir(dir)) != nullptr)
+	{
+		if (strcmp(ent->d_name, ".") == 0 || strcmp(ent->d_name, "..") == 0)
+		{
+			continue;
+		}
+
+		struct stat child_st = {};
+		if (fstatat(dfd, ent->d_name, &child_st, 0) != 0)
+		{
+			continue;
+		}
+
+		dir_children.insert(FileKey{
+			.dev = child_st.st_dev,
+			.inode = child_st.st_ino,
+		});
+	}
+
+	closedir(dir);
+	return 0;
+}
+
+static void parse_args(int argc, char *args[])
 {
 	int opt, opt_idx;
-	int optbits = 0;
+	int mode_count = 0;
+	std::vector<char *> filtered_args;
+
+	filtered_args.push_back(args[0]);
+	for (int i = 1; i < argc; i++)
+	{
+		if (strcmp(args[i], "+d") == 0)
+		{
+			if (i + 1 >= argc)
+			{
+				fprintf(stderr, "error: +d requires a directory argument\n");
+				exit(-1);
+			}
+			strncpy(rule.dir_path, args[i + 1], sizeof(rule.dir_path));
+			rule.dir_path[sizeof(rule.dir_path) - 1] = 0;
+			rule.mode = QUERY_DIR_CHILDREN;
+			mode_count++;
+			i++;
+			continue;
+		}
+		filtered_args.push_back(args[i]);
+	}
+	filtered_args.push_back(nullptr);
+
 	optind = 1;
 	std::string sopts = long_opt2short_opt(lopts);
-	while ((opt = getopt_long(argc, args, sopts.c_str(), lopts, &opt_idx)) > 0)
+	while ((opt = getopt_long(
+				static_cast<int>(filtered_args.size() - 1),
+				filtered_args.data(),
+				sopts.c_str(),
+				lopts,
+				&opt_idx
+			)) > 0)
 	{
 		switch (opt)
 		{
 		case 'p':
 			strncpy(rule.path, optarg, sizeof(rule.path));
 			rule.path[sizeof(rule.path) - 1] = 0;
-			optbits |= 1;
+			rule.mode = QUERY_SINGLE_OBJECT;
+			mode_count++;
 			break;
 		case 'd':
-			rule.dev = strtoul(optarg, NULL, 10); // 直接解析设备号
-			rule.not_inode = 0;
-			optbits |= 1 << 1;
+			rule.dev = strtoul(optarg, NULL, 10);
 			break;
 		case 'i':
-			rule.inode = atoi(optarg);
-			rule.not_inode = 0;
-			optbits |= 1 << 2;
+			rule.inode = strtoull(optarg, NULL, 10);
+			break;
+		case 1000:
+			rule.dev = strtoul(optarg, NULL, 10);
+			rule.mode = QUERY_FS_DEV;
+			mode_count++;
 			break;
 		case 'h':
 			Usage(args[0]);
 			exit(0);
-			break;
 		default:
 			Usage(args[0]);
 			exit(-1);
-			break;
 		}
 	}
 
-	if ((optbits & 1) && (optbits & 4))
+	if (rule.mode == QUERY_NONE && rule.dev != 0 && rule.inode != 0)
 	{
-		printf("error: -p and -i can't be used together\n");
+		rule.mode = QUERY_SINGLE_OBJECT;
+		mode_count++;
+	}
+
+	if (mode_count != 1)
+	{
+		fprintf(
+			stderr,
+			"error: specify exactly one of -p, -d/-i, --fs-dev, or +d\n"
+		);
 		exit(-1);
 	}
 
-	if (!!(optbits & 2) ^ !!(optbits & 4))
+	if (rule.mode == QUERY_SINGLE_OBJECT && rule.path[0] != '\0')
 	{
-		printf("error: -d and -i must be used together\n"); // 更新错误信息
+		int err = resolve_path_rule();
+		if (err)
+		{
+			fprintf(
+				stderr,
+				"failed to stat %s: %s\n",
+				rule.path,
+				strerror(-err)
+			);
+			exit(-1);
+		}
+	}
+	else if (rule.mode == QUERY_SINGLE_OBJECT &&
+			 (rule.dev == 0 || rule.inode == 0))
+	{
+		fprintf(stderr, "error: -d and -i must be used together\n");
 		exit(-1);
+	}
+	else if (rule.mode == QUERY_DIR_CHILDREN)
+	{
+		int err = collect_dir_children(rule.dir_path);
+		if (err)
+		{
+			fprintf(
+				stderr,
+				"failed to scan directory %s: %s\n",
+				rule.dir_path,
+				strerror(-err)
+			);
+			exit(-1);
+		}
 	}
 }
 
-static int handle_event(void *ctx, void *data, size_t data_sz)
+static bool match_file(dev_t dev, unsigned long inode)
 {
-	const struct BpfData *log = (const struct BpfData *)data;
-	u64 key = log->pid;
-	log_stat[key].push_back(*log);
-	return 0;
+	switch (rule.mode)
+	{
+	case QUERY_SINGLE_OBJECT:
+		return rule.dev == dev && rule.inode == inode;
+	case QUERY_FS_DEV:
+		return rule.dev == dev;
+	case QUERY_DIR_CHILDREN:
+		return dir_children.find(FileKey{dev, inode}) != dir_children.end();
+	default:
+		return false;
+	}
+}
+
+static void update_entry(pid_t pid, const char *comm)
+{
+	auto &entry = log_stat[pid];
+	entry.pid = pid;
+	entry.comm = comm;
+	auto uid_it = uid_stat.find(pid);
+	if (uid_it != uid_stat.end())
+	{
+		entry.uid = uid_it->second;
+	}
+}
+
+static int handle_event(void *ctx, const void *data, size_t data_sz)
+{
+	(void)ctx;
+
+	if (!data || data_sz < sizeof(DKapture::DataHdr))
+	{
+		return -EINVAL;
+	}
+
+	const auto *hdr = static_cast<const DKapture::DataHdr *>(data);
+	switch (hdr->type)
+	{
+	case DKapture::PROC_PID_FD:
+	{
+		if (hdr->dsz < sizeof(DKapture::DataHdr) + sizeof(ProcPidFd) ||
+			data_sz < hdr->dsz)
+		{
+			return -EINVAL;
+		}
+
+		const auto *fd = reinterpret_cast<const ProcPidFd *>(hdr->data);
+		if (!match_file(fd->dev, fd->inode))
+		{
+			return 0;
+		}
+
+		update_entry(hdr->pid, hdr->comm);
+		log_stat[hdr->pid].fds.push_back(fd->fd);
+		return 0;
+	}
+	case DKapture::PROC_PID_STATUS:
+	{
+		if (hdr->dsz < sizeof(DKapture::DataHdr) + sizeof(ProcPidStatus) ||
+			data_sz < hdr->dsz)
+		{
+			return -EINVAL;
+		}
+
+		const auto *status = reinterpret_cast<const ProcPidStatus *>(hdr->data);
+		uid_stat[hdr->pid] = status->uid[0];
+		auto it = log_stat.find(hdr->pid);
+		if (it != log_stat.end())
+		{
+			it->second.uid = status->uid[0];
+		}
+		return 0;
+	}
+	case DKapture::PROC_PID_VMA_FILE:
+	{
+		if (hdr->dsz <
+				sizeof(DKapture::DataHdr) + sizeof(ProcPidVmaFile) ||
+			data_sz < hdr->dsz)
+		{
+			return -EINVAL;
+		}
+
+		const auto *vma =
+			reinterpret_cast<const ProcPidVmaFile *>(hdr->data);
+		if (!match_file(vma->dev, vma->inode))
+		{
+			return 0;
+		}
+
+		update_entry(hdr->pid, hdr->comm);
+		log_stat[hdr->pid].vma_cnt++;
+		return 0;
+	}
+	default:
+		return 0;
+	}
 }
 
 static void summary_print(void)
@@ -194,145 +440,109 @@ static void summary_print(void)
 	printf("--------------------------------------------\n");
 	for (auto &it : log_stat)
 	{
-		std::vector<struct BpfData> &logs = it.second;
-		pid_t pid = it.first;
-		uid_t uid = logs[0].uid;
-		char *comm = logs[0].comm;
-		printf("%16s %6d %8d   ", comm, uid, pid);
-		size_t vma_cnt = 0;
-		for (auto &log : logs)
+		LsofEntry &entry = it.second;
+		printf(
+			"%16s %6d %8d   ",
+			entry.comm.c_str(),
+			entry.uid,
+			entry.pid
+		);
+
+		for (int fd : entry.fds)
 		{
-			if (log.fd == -1)
-			{
-				vma_cnt++;
-			}
-			else
-			{
-				printf("%d ", log.fd);
-			}
+			printf("%d ", fd);
 		}
-		if (vma_cnt)
+
+		if (entry.vma_cnt)
 		{
-			printf("vma(%ld)\n", vma_cnt);
+			printf("vma(%ld)", entry.vma_cnt);
 		}
-		else
-		{
-			printf("\n");
-		}
+		printf("\n");
 	}
 	printf("\n");
 }
 
-void *ringbuf_worker(void *)
+static void print_scan_target(void)
 {
-	while (!exit_flag)
+	printf("Scanning ");
+	switch (rule.mode)
 	{
-		int err = ring_buffer__poll(rb, 100 /* timeout in ms */);
-
-		if (err < 0 && err != -EINTR)
+	case QUERY_SINGLE_OBJECT:
+		if (rule.path[0] != '\0')
 		{
-			pr_error("Error polling ring buffer: %d\n", err);
-			sleep(5);
+			printf(
+				"file %s (dev=%lu inode=%llu)",
+				rule.path,
+				(unsigned long)rule.dev,
+				rule.inode
+			);
 		}
-
-		if (err == 0 && iter_fd == -1)
+		else
 		{
-			break;
+			printf("(dev=%lu inode=%llu)", (unsigned long)rule.dev, rule.inode);
 		}
+		break;
+	case QUERY_FS_DEV:
+		printf("filesystem device dev=%lu", (unsigned long)rule.dev);
+		break;
+	case QUERY_DIR_CHILDREN:
+		printf(
+			"direct children of %s (%zu objects)",
+			rule.dir_path,
+			dir_children.size()
+		);
+		break;
+	default:
+		printf("unknown target");
+		break;
 	}
-	stop_trace();
-	kill(getpid(), SIGINT);
-	return NULL;
-}
-
-void register_signal()
-{
-	struct sigaction sa;
-	sa.sa_handler = [](int) { exit_flag = true; };
-	sa.sa_flags = 0;
-	sigemptyset(&sa.sa_mask);
-
-	if (sigaction(SIGINT, &sa, NULL) == -1)
-	{
-		perror("sigaction");
-		exit(EXIT_FAILURE);
-	}
+	printf("...\n");
 }
 
 int main(int argc, char *args[])
 {
-	ssize_t rd_sz = 0;
-	char buf[PATH_MAX] = {0};
-
 	parse_args(argc, args);
-	register_signal();
 
-	int key = 0;
-	obj = lsof_bpf::open_and_load();
-	if (!obj)
+	std::unique_ptr<DKapture> dk(DKapture::new_instance());
+	if (!dk)
 	{
-		exit(-1);
+		fprintf(stderr, "Failed to create DKapture instance\n");
+		return 1;
 	}
 
-	if (0 != lsof_bpf::attach(obj))
+	int err = dk->open(stderr, DKapture::INFO);
+	if (err)
 	{
-		exit(-1);
+		fprintf(
+			stderr,
+			"Failed to open DKapture: %d (%s)\n",
+			-err,
+			strerror(-err)
+		);
+		return 1;
 	}
 
-	filter_fd = bpf_get_map_fd(obj->obj, "filter", goto err_out);
-
-	if (0 != bpf_map_update_elem(filter_fd, &key, &rule, BPF_ANY))
+	std::vector<DKapture::DataType> dts = {
+		DKapture::PROC_PID_FD,
+		DKapture::PROC_PID_STATUS,
+		DKapture::PROC_PID_VMA_FILE,
+	};
+	ssize_t ret = dk->read(dts, handle_event, nullptr);
+	if (ret < 0)
 	{
-		printf("Error: bpf_map_update_elem");
-		goto err_out;
+		fprintf(
+			stderr,
+			"Failed to read process file usage: %ld (%s)\n",
+			-ret,
+			strerror(-ret)
+		);
+		dk->close();
+		return 1;
 	}
 
-	log_map_fd = bpf_get_map_fd(obj->obj, "logs", goto err_out);
-	rb = ring_buffer__new(log_map_fd, handle_event, NULL, NULL);
-	if (!rb)
-	{
-		goto err_out;
-	}
-
-	iter_fd = bpf_iter_create(bpf_link__fd(obj->links.file_iterator));
-	if (iter_fd < 0)
-	{
-		fprintf(stderr, "Error creating BPF iterator\n");
-		goto err_out;
-	}
-
-	while ((rd_sz = read(iter_fd, buf, sizeof(buf))) > 0)
-	{
-	}
-
-	close(iter_fd);
-	iter_fd = bpf_iter_create(bpf_link__fd(obj->links.vma_iterator));
-	if (iter_fd < 0)
-	{
-		fprintf(stderr, "Error creating BPF iterator\n");
-		goto err_out;
-	}
-
-	while ((rd_sz = read(iter_fd, buf, sizeof(buf))) > 0)
-	{
-	}
-
-	close(iter_fd);
-	iter_fd = -1;
-
-	printf("Scanning for file %s...\n", rule.path);
-	//! TODO ringbuffer消耗不及时, 后续修复
-	pthread_create(&t1, NULL, ringbuf_worker, NULL);
-	follow_trace_pipe();
-	pthread_join(t1, NULL);
+	print_scan_target();
 	summary_print();
 
-err_out:
-	if (rb)
-	{
-		ring_buffer__free(rb);
-	}
-	lsof_bpf::detach(obj);
-	lsof_bpf::destroy(obj);
+	dk->close();
 	return 0;
 }


### PR DESCRIPTION
- replace direct BPF skeleton usage with DKapture reads
- support -p, -d/-i, --fs-dev, +d
- preserve fd and vma aggregation output