### PR TITLE
fix(trace-exec): reject invalid command line arguments and add support builtin testing

### DIFF
--- a/observe/trace-exec.cpp
+++ b/observe/trace-exec.cpp
@@ -15,6 +15,12 @@
 #include <signal.h>
 #include <string>
 #include <atomic>
+#ifdef BUILTIN
+#include <map>
+#include <tuple>
+#include <thread>
+#include <chrono>
+#endif
 #include <pthread.h>
 #include "trace-exec.skel.h"
 #include "com.h"
@@ -22,7 +28,7 @@
 // BPF object for tracing execution
 static trace_exec_bpf *obj;
 static int filter_fd;
-struct ring_buffer *rb = NULL;
+static struct ring_buffer *rb = NULL;
 static int log_map_fd;
 static pthread_t t1;
 static std::atomic<bool> exit_flag(false);
@@ -33,10 +39,25 @@ struct Rule
 	char target_path[PATH_MAX]; // Path to filter on
 	uint32_t depth;				// Depth of the printed task chain
 	uint32_t uid;				// User ID to filter on
-} rule = {
+};
+static struct Rule rule = {
 	.depth = 50,		// Default depth
 	.uid = (uint32_t)-1 // Default UID (no filtering)
 };
+
+#ifdef BUILTIN
+static FILE *stdout_bak;
+static std::map<std::string, std::tuple<int, int, int, bpf_map_type>>
+	local_map_info = {
+		{"filter", {sizeof(uint32_t), sizeof(struct Rule), 1, BPF_MAP_TYPE_HASH}},
+		{"logs",   {0, 1, 1024 * 1024, BPF_MAP_TYPE_RINGBUF}                  },
+	};
+static std::atomic<int> *condition;
+static int *filter_fdp;
+static int *log_fdp;
+extern std::string test_name;
+extern std::map<std::string, std::tuple<int, int, int, bpf_map_type>> *map_info;
+#endif
 
 // Long options for command line arguments
 static struct option lopts[] = {
@@ -63,7 +84,7 @@ static HelpMsg help_msg[] = {
 };
 
 // Function to display usage information
-void Usage(const char *arg0)
+static void Usage(const char *arg0)
 {
 	printf("Usage: %s [option]\n", arg0);
 	printf("  trace exec event on the system, support filter with process "
@@ -86,7 +107,7 @@ void Usage(const char *arg0)
 }
 
 // Convert long options to short options for getopt
-std::string long_opt2short_opt(const option lopts[])
+static std::string long_opt2short_opt(const option lopts[])
 {
 	std::string sopts = "";
 	for (int i = 0; lopts[i].name; i++)
@@ -112,10 +133,11 @@ std::string long_opt2short_opt(const option lopts[])
 }
 
 // Parse command line arguments
-void parse_args(int argc, char **argv)
+static int parse_args(int argc, char **argv)
 {
 	int opt, opt_idx;
-	optind = 1;
+	optind = 0;
+	opterr = 0;
 	std::string sopts = long_opt2short_opt(lopts); // Convert long options to
 												   // short options
 	while ((opt = getopt_long(argc, argv, sopts.c_str(), lopts, &opt_idx)) > 0)
@@ -123,25 +145,43 @@ void parse_args(int argc, char **argv)
 		switch (opt)
 		{
 		case 'u': // UID option
-			rule.uid = strtol(optarg, NULL, 10);
+		{
+			char *end = nullptr;
+			errno = 0;
+			long val = strtol(optarg, &end, 10);
+			if (end == optarg || *end != '\0' ||  errno == ERANGE || val < 0 || (unsigned long)val > UINT32_MAX)
+			{
+				printf("wrong uid value: %s, must be a non-negative integer\n", optarg);
+				return -1;
+			}
+			rule.uid = (uint32_t)val;
 			break;
+		}
 		case 'd': // Depth option
-			rule.depth = strtol(optarg, NULL, 10);
+		{
+			char *end = nullptr;
+			long val = strtol(optarg, &end, 10);
+			if (end == optarg || *end != '\0' || val <= 0)
+			{
+				printf("wrong depth value: %s, must be a positive integer\n", optarg);
+				return -1;
+			}
+			rule.depth = (uint32_t)val;
 			break;
+		}
 		case 'h': // Help option
 			Usage(argv[0]);
-			exit(0);
-			break;
+			return 1;
 		case 't': // Target path option
 			strncpy(rule.target_path, optarg, PATH_MAX);
 			rule.target_path[PATH_MAX - 1] = 0;
 			break;
 		default: // Invalid option
 			Usage(argv[0]);
-			exit(-1);
-			break;
+			return -1;
 		}
 	}
+	return 0;
 }
 
 static int handle_event(void *ctx, void *data, size_t data_sz)
@@ -155,7 +195,11 @@ void *ringbuf_worker(void *)
 {
 	while (!exit_flag)
 	{
+#ifdef BUILTIN
+		int err = ring_buffer__poll(rb, 50 /* timeout in ms */);
+#else
 		int err = ring_buffer__poll(rb, 1000 /* timeout in ms */);
+#endif
 		if (err < 0 && err != -EINTR)
 		{
 			pr_error("Error polling ring buffer: %d\n", err);
@@ -165,7 +209,42 @@ void *ringbuf_worker(void *)
 	return NULL;
 }
 
-void register_signal()
+#ifdef BUILTIN
+void trace_exec_init(
+	FILE *output,
+	std::atomic<int> *conditionp,
+	std::atomic<bool> **exit_flagp,
+	int *filter_fd,
+	int *log_fd
+)
+{
+	test_name = "trace-exec";
+	map_info = &local_map_info;
+	condition = conditionp;
+	*exit_flagp = &exit_flag;
+	filter_fdp = filter_fd;
+	log_fdp = log_fd;
+	rb = NULL;
+	memset(&rule, 0, sizeof(rule));
+	rule.depth = 50;
+	rule.uid = (uint32_t)-1;
+	exit_flag = false;
+	stdout_bak = stdout;
+	fflush(stdout);
+	stdout = output;
+	Log::set_file(output);
+}
+void trace_exec_deinit()
+{
+	test_name = "";
+	map_info = NULL;
+	fflush(stdout);
+	stdout = stdout_bak;
+	Log::set_file(stderr);
+}
+#endif
+
+static int register_signal()
 {
 	struct sigaction sa;
 	sa.sa_handler = [](int)
@@ -179,45 +258,79 @@ void register_signal()
 	if (sigaction(SIGINT, &sa, NULL) == -1)
 	{
 		perror("sigaction");
-		exit(EXIT_FAILURE);
+		return -1;
 	}
+	return 0;
 }
 
 // Main function
+#ifdef BUILTIN
+int trace_exec_main(int argc, char *args[])
+#else
 int main(int argc, char *args[])
+#endif
 {
-	parse_args(argc, args); // Parse command line arguments
-	register_signal();
+	int ret = parse_args(argc, args); // Parse command line arguments
+	if (ret != 0)
+	{
+#ifdef BUILTIN
+		*condition = 2;
+#endif
+		return ret;
+	}
+#ifndef BUILTIN
+	ret = register_signal();
+	if (ret < 0)
+	{
+		return ret;
+	}
+#endif
 	int key = 0;						   // Key for BPF map
 	obj = trace_exec_bpf::open_and_load(); // Load BPF program
 	if (!obj)
 	{
-		exit(-1); // Exit if loading fails
+		return -1; // Exit if loading failed
 	}
 
 	if (0 != trace_exec_bpf::attach(obj))
 	{
-		exit(-1); // Exit if attaching fails
+		return -1; // Attach BPF program failed
 	}
 
 	// Get the file descriptor for the BPF map
 	filter_fd = bpf_get_map_fd(obj->obj, "filter", goto err_out);
+#ifdef BUILTIN
+	*filter_fdp = filter_fd;
+#endif
 	if (0 != bpf_map_update_elem(filter_fd, &key, &rule, BPF_ANY))
 	{
 		printf("error: bpf_map_update_elem\n"); // Print error if updating fails
+		ret = -1;
 		goto err_out;							// Go to error handling
 	}
 	log_map_fd = bpf_get_map_fd(obj->obj, "logs", goto err_out);
+#ifdef BUILTIN
+	*log_fdp = log_map_fd;
+#endif
 	rb = ring_buffer__new(log_map_fd, handle_event, NULL, NULL);
 	if (!rb)
 	{
 		goto err_out; // Handle error
 	}
-
 	pthread_create(&t1, NULL, ringbuf_worker, NULL);
+	printf("Tracing exec events... Hit Ctrl-C to end.\n");
+#ifndef BUILTIN
 	follow_trace_pipe(); // Start reading from the trace pipe
-
+#else
+	*condition = 1;
+	while(!exit_flag)
+	{
+		std::this_thread::sleep_for(std::chrono::microseconds(5));
+	}
+#endif
+#ifndef BUILTIN
 	pthread_kill(t1, SIGINT);
+#endif
 	pthread_join(t1, NULL);
 
 err_out:
@@ -227,5 +340,5 @@ err_out:
 	}
 	trace_exec_bpf::detach(obj);  // Detach BPF program
 	trace_exec_bpf::destroy(obj); // Clean up BPF object
-	return 0;					  // Exit successfully
+	return 0; // Exit successfully
 }


### PR DESCRIPTION
### 对本次trace-exec工具修改的内容

1. 补齐 BUILTIN 测试入口，改为通过返回值处理参数解析结果
2. 增加工具启动后的运行提示
3. 增添用户传入异常参数时会报错反馈的功能，原来的代码如下: 
```cpp
void parse_args(int argc, char **argv)
{
	int opt, opt_idx;
	optind = 1;
	std::string sopts = long_opt2short_opt(lopts); // Convert long options to
												   // short options
	while ((opt = getopt_long(argc, argv, sopts.c_str(), lopts, &opt_idx)) > 0)
	{
		switch (opt)
		{
		case 'u': // UID option
			rule.uid = strtol(optarg, NULL, 10);
			break;
		case 'd': // Depth option
			rule.depth = strtol(optarg, NULL, 10);
			break;
		case 'h': // Help option
			Usage(argv[0]);
			exit(0);
			break;
		case 't': // Target path option
			strncpy(rule.target_path, optarg, PATH_MAX);
			rule.target_path[PATH_MAX - 1] = 0;
			break;
		default: // Invalid option
			Usage(argv[0]);
			exit(-1);
			break;
		}
	}
}
```
当用户传入-d -u的参数是负数或字母或极大值时，不会报错反馈给用户，导致工具状态异常，但是用户侧得不到反馈。现已增加参数异常报错反馈