### PR TITLE
fix: make power-snoop internal symbols static for test linking

### DIFF
--- a/observe/power-snoop.cpp
+++ b/observe/power-snoop.cpp
@@ -42,7 +42,8 @@ struct env
 	bool summary;
 	time_t interval;
 	int times;
-} env = {
+}; 
+static struct env env = {
 	.pid = 0,
 	.cpu = (__u32)-1,
 	.comm = "",
@@ -493,7 +494,7 @@ static void print_stats(void)
 	printf("RPM events:       %llu\n", global_stats.rpm_events);
 }
 
-void ringbuffer_worker(void)
+static void ringbuffer_worker(void)
 {
 	int err;
 	while (!exiting && --env.times != 0)


### PR DESCRIPTION
为避免 power-snoop 在单测聚合链接时与其他 observe 工具发生同名全局符号冲突，将仅在本文件使用的运行时状态和辅助函数收敛为内部链接，不改变工具功能，只修复 make test 阶段的 multiple definition 问题。