### PR TITLE
test: add trace-exec testing and fix trace-exec mock stability

### DIFF
--- a/test/Makefile
+++ b/test/Makefile
@@ -23,7 +23,8 @@ CXXFLAGS = -g -D__GTEST__ -DBUILTIN -MMD \
 		   -I$(PROJ_ROOT)/build/policy \
 		   -I$(PROJ_ROOT)/bpf/export
 
-LDFLAGS = -Wl,-rpath=$(PROJ_ROOT)/googletest/build/lib/
+LDFLAGS = -Wl,-rpath='$$ORIGIN/../../googletest/build/lib'
+LDLIBS = -lbpf -lpthread -lelf -lz
 
 GTEST_LIBS = $(PROJ_ROOT)/googletest/build/lib/libgtest_main.so	\
 			 $(PROJ_ROOT)/googletest/build/lib/libgtest.so
@@ -43,9 +44,10 @@ $(TARGET): $(OBJS) $(GTEST_LIBS) \
 	$(BUILD_DIR)/kmemleak.o \
 	$(BUILD_DIR)/irqsnoop.o \
 	$(BUILD_DIR)/mountsnoop.o \
+	$(BUILD_DIR)/trace-exec.o \
 	$(BUILD_DIR)/frtp.o \
 	$(BUILD_DIR)/elfverify.o
-	$(CXX) $^ $(LDFLAGS) -o $@
+	$(CXX) $^ $(LDFLAGS) $(LDLIBS) -o $@
 
 $(BUILD_DIR):
 	@mkdir -p $@

--- a/test/mock.cpp
+++ b/test/mock.cpp
@@ -68,6 +68,7 @@ struct bpf_map
 	size_t value_size;
 	size_t max_entries;
 	size_t sz;
+	size_t mmap_sz;
 	void *mem;
 	bpf_map_type type;
 	std::string name;
@@ -81,6 +82,15 @@ struct bpf_object
 	std::vector<bpf_link> links;
 };
 
+struct skeleton_offsets
+{
+	size_t map_base;
+	size_t prog_base;
+	size_t link_base;
+	int map_cnt;
+	int prog_cnt;
+};
+
 struct ring_buffer
 {
 	int map_fd;
@@ -90,6 +100,7 @@ struct ring_buffer
 };
 
 static bpf_object g_obj;
+static std::map<const bpf_object_skeleton *, skeleton_offsets> g_skeleton_offsets;
 
 std::string fd_path(int fd)
 {
@@ -293,22 +304,52 @@ void bpf_object__destroy_skeleton(struct bpf_object_skeleton *s)
 		return;
 	}
 
-	int fd;
-	char buf[PATH_MAX];
-
-	for (int i = 0; i < s->prog_cnt; i++)
+	auto offset_it = g_skeleton_offsets.find(s);
+	if (offset_it == g_skeleton_offsets.end())
 	{
-		close(g_obj.progs[i].fd);
-		close(g_obj.links[i].fd);
+		free(s->maps);
+		free(s->progs);
+		free(s);
+		return;
 	}
-	g_obj.progs.clear();
-	g_obj.links.clear();
+	const skeleton_offsets offsets = offset_it->second;
+
 	for (int i = 0; i < s->map_cnt; i++)
 	{
-		munmap(g_obj.maps[i].mem, g_obj.maps[i].sz);
-		close(g_obj.maps[i].fd);
+		if (s->maps[i].mmaped && *s->maps[i].mmaped)
+		{
+			free(*s->maps[i].mmaped);
+			*s->maps[i].mmaped = nullptr;
+		}
 	}
-	g_obj.maps.clear();
+
+	for (int i = 0; i < offsets.prog_cnt; i++)
+	{
+		close(g_obj.progs[offsets.prog_base + i].fd);
+		close(g_obj.links[offsets.link_base + i].fd);
+	}
+	g_obj.progs.erase(
+		g_obj.progs.begin() + offsets.prog_base,
+		g_obj.progs.begin() + offsets.prog_base + offsets.prog_cnt
+	);
+	g_obj.links.erase(
+		g_obj.links.begin() + offsets.link_base,
+		g_obj.links.begin() + offsets.link_base + offsets.prog_cnt
+	);
+	for (int i = 0; i < offsets.map_cnt; i++)
+	{
+		bpf_map &map = g_obj.maps[offsets.map_base + i];
+		if (map.mem)
+		{
+			munmap(map.mem, map.mmap_sz ? map.mmap_sz : map.sz);
+		}
+		close(map.fd);
+	}
+	g_obj.maps.erase(
+		g_obj.maps.begin() + offsets.map_base,
+		g_obj.maps.begin() + offsets.map_base + offsets.map_cnt
+	);
+	g_skeleton_offsets.erase(offset_it);
 	free(s->maps);
 	free(s->progs);
 	free(s);
@@ -319,7 +360,7 @@ int bpf_object__find_map_fd_by_name(
 	const char *name
 )
 {
-	for (int i = 0; i < obj->maps.size(); i++)
+	for (int i = (int)obj->maps.size() - 1; i >= 0; i--)
 	{
 		if (obj->maps[i].name == name)
 		{
@@ -345,15 +386,21 @@ int bpf_object__open_skeleton(
 
 	*s->obj = &g_obj;
 
+	const size_t map_base = g_obj.maps.size();
+	const size_t prog_base = g_obj.progs.size();
+	const size_t link_base = g_obj.links.size();
+	g_obj.maps.reserve(map_base + s->map_cnt);
+	g_obj.progs.reserve(prog_base + s->prog_cnt);
+	g_obj.links.reserve(link_base + s->prog_cnt);
+	g_skeleton_offsets[s] = {map_base, prog_base, link_base, s->map_cnt, s->prog_cnt};
+
 	int fd;
-	bpf_program prog;
-	bpf_map map;
-	bpf_link link;
 	const char *name;
 	char buf[PATH_MAX];
 
 	for (int i = 0; i < s->map_cnt; i++)
 	{
+		bpf_map map {};
 		name = s->maps[i].name;
 		snprintf(buf, PATH_MAX, "%s/map-%s", BPF_PIN_PATH, name);
 		fd = open(buf, O_RDWR | O_TRUNC | O_CREAT, 0600);
@@ -378,35 +425,43 @@ int bpf_object__open_skeleton(
 			map.sz = RB_MAP_SIZE;
 			map.type = BPF_MAP_TYPE_UNSPEC;
 		}
+		map.mmap_sz = 0;
 		int page_size = getpagesize();
 		if (strcmp(name, "dk_shared_mem") == 0 ||
 			map.type == BPF_MAP_TYPE_RINGBUF)
 		{
 			int ret = 0;
-			ret = ftruncate(fd, page_size * 2 + RB_MAP_SIZE);
+			map.mmap_sz = page_size * 2 + RB_MAP_SIZE;
+			ret = ftruncate(fd, map.mmap_sz);
 			assert(ret == 0);
 			map.type = BPF_MAP_TYPE_RINGBUF;
 			map.mem = mmap(
 				NULL,
-				page_size * 2 + RB_MAP_SIZE,
+				map.mmap_sz,
 				PROT_READ | PROT_WRITE,
 				MAP_SHARED,
 				fd,
 				0
 			);
 			assert(map.mem != MAP_FAILED);
-			memset(map.mem, 0, page_size * 2 + RB_MAP_SIZE);
+			memset(map.mem, 0, map.mmap_sz);
 		}
 		else
 		{
 			map.mem = nullptr;
 		}
 		g_obj.maps.push_back(std::move(map));
-		*s->maps[i].map = &g_obj.maps[i];
+		*s->maps[i].map = &g_obj.maps[map_base + i];
+		if (s->maps[i].mmaped)
+		{
+			*s->maps[i].mmaped = calloc(1, getpagesize());
+			assert(*s->maps[i].mmaped != nullptr);
+		}
 	}
 
 	for (int i = 0; i < s->prog_cnt; i++)
 	{
+		bpf_program prog {};
 		name = s->progs[i].name;
 		snprintf(buf, PATH_MAX, "%s/prog-%s", BPF_PIN_PATH, name);
 		fd = open(buf, O_RDWR | O_TRUNC | O_CREAT, 0600);
@@ -432,8 +487,9 @@ int bpf_object__open_skeleton(
 			}
 		}
 		g_obj.progs.push_back(std::move(prog));
-		*s->progs[i].prog = &g_obj.progs[i];
+		*s->progs[i].prog = &g_obj.progs[prog_base + i];
 
+		bpf_link link {};
 		snprintf(buf, PATH_MAX, "%s/link-%s", BPF_PIN_PATH, name);
 		fd = open(buf, O_RDWR | O_TRUNC | O_CREAT, 0600);
 		if (fd < 0)
@@ -442,9 +498,9 @@ int bpf_object__open_skeleton(
 		}
 		link.fd = fd;
 		link.pin_path = buf;
-		link.prog = &g_obj.progs[i];
+		link.prog = &g_obj.progs[prog_base + i];
 		g_obj.links.push_back(std::move(link));
-		*s->progs[i].link = &g_obj.links[i];
+		*s->progs[i].link = &g_obj.links[link_base + i];
 	}
 	return 0;
 }

--- a/test/trace-exec-test.cpp
+++ b/test/trace-exec-test.cpp
@@ -1,0 +1,463 @@
+// SPDX-FileCopyrightText: 2025 UnionTech Software Technology Co., Ltd
+//
+// SPDX-License-Identifier: LGPL-2.1
+
+// This file uses/derives from googletest
+// Copyright 2008, Google Inc.
+// Licensed under the BSD 3-Clause License
+// See NOTICE for full license text
+
+#include "gtest/gtest.h"
+
+#include <atomic>
+#include <algorithm>
+#include <cstdio>
+#include <cstring>
+#include <filesystem>
+#include <fstream>
+#include <string>
+#include <thread>
+#include <vector>
+
+#include "com.h"
+#include <bpf/bpf.h>
+
+#define PATH_MAX 4096 
+#define COMM_MAX_LEN 16
+#define CHAIN_MAX_DEPTH 128
+#define TEST_EVENT_MAX 32
+
+struct Rule
+{
+	char target_path[4096];
+	uint32_t depth;
+	uint32_t uid;
+};
+
+struct Test_Event
+{
+	uint32_t uid;
+	char path[PATH_MAX];
+	uint32_t depth;
+	uint32_t chain_len;
+	char comm[CHAIN_MAX_DEPTH][COMM_MAX_LEN];
+	pid_t pid[CHAIN_MAX_DEPTH];
+};
+struct Buf
+{
+	char path[PATH_MAX]; // Path of the file
+	char log[PATH_MAX];	 // Log information
+};
+
+static const std::string TEST_ROOT = "/tmp/trace_exec_test_dir";
+static const std::string TEST_LOG_FILE = TEST_ROOT + "/log.txt";
+static Test_Event g_test_events[TEST_EVENT_MAX] = {};
+static size_t g_test_event_count = 0;
+static std::atomic<int> g_condition = 0;
+static std::atomic<bool> *g_exit_flag = nullptr;
+
+extern void trace_exec_init(
+	FILE *output,
+	std::atomic<int> *conditionp,
+	std::atomic<bool> **exit_flagp,
+	int *filter_fd,
+	int *log_fd
+);
+extern int trace_exec_main(int argc, char *argv[]);
+extern void trace_exec_deinit();
+extern long bpf_for_each_map_elem(int fd, void *callback_fn, void *callback_ctx, unsigned long long flags);
+extern int ring_buffer__push(int fd, void *data, size_t sz);
+
+// Function to concatenate strings with a limit
+static inline void strncat(void *dst, long dsz, const void *src, long ssz)
+{
+	char *d = (char *)(dst);
+	const char *s = (const char *)src;
+	// Copy until the source string ends or destination space runs out
+	while (ssz > 0 && dsz > 0)
+	{
+		if (*s == 0)
+		{
+			return; // Stop if end of source string is reached
+		}
+		*d++ = *s++; // Copy character
+		ssz--;
+		dsz--; // Decrement sizes
+	}
+}
+static long match_call(struct bpf_map *map, const void *key, void *value, void *ctx)
+{
+    struct Test_Event *test_event = (struct Test_Event *)ctx;
+    struct Rule *rule = (struct Rule *)value;
+    if(rule->uid > 0 && rule->uid != (uint32_t)-1 && test_event->uid != rule->uid){
+        return 0;
+    }
+    if(rule->target_path[0] != '\0' &&
+          strncmp(test_event->path, rule->target_path, sizeof(rule->target_path)) != 0)
+    {
+         return 0;
+    }
+	if (rule->depth > 128)
+	{
+		test_event->depth = 128; // Limit depth to 50
+	}
+    test_event->depth = rule->depth;
+    return 1;
+}
+static bool rules_filter(int filter_fd, struct Test_Event &event)
+{
+    return bpf_for_each_map_elem(filter_fd, (void *)match_call, &event, 0) == 1;
+}
+
+static int add_buf_to_ringbuf(struct Test_Event &test_event, struct Buf &buf)
+{
+	char *pbuf = buf.path;	  // Buffer for path
+	char *log = buf.log;	  // Buffer for log
+	long log_left = PATH_MAX; // Remaining space in log
+
+	if (test_event.chain_len == 0)
+	{
+		return 0;
+	}
+	int ret = snprintf(pbuf, 32, "%s(%d)", test_event.comm[0], (int)test_event.pid[0]);
+	if (ret < 1)
+	{
+		printf("error: bpf_snprintf: %d", ret); // Log error
+		return 0;
+	}
+	if (ret > 32)
+	{
+		return 0; // Overflow check
+	}
+	strncat(log, log_left, pbuf, 32); // Concatenate to log
+	log_left -= ret;			  // Update remaining space
+	log += ret;					  // Move log pointer
+
+	int loop_limit = 0; // Limit for loops
+	int key = 1; // index for comm and pid
+	do
+	{
+        if (key >= (int)test_event.chain_len)
+        {
+            break;
+        }
+		int ret = snprintf(pbuf, 32, "<-%s(%d)", test_event.comm[key], (int)test_event.pid[key]);
+		if (ret < 1)
+		{
+			printf("error: bpf_snprintf: %d", ret); // Log error
+			break;
+		}
+		if (ret > 32)
+		{
+			printf("impossible code branch reached");// Overflow check
+			break;
+		}
+		strncat(log, log_left, pbuf, 32); // Concatenate to log
+		log_left -= ret;			  // Update remaining space
+		log += ret;					  // Move log pointer
+		if (test_event.pid[key] == 1 || loop_limit++ >= test_event.depth)
+		{
+			break; // Stop if reached root or limit
+		}
+		key++;
+	} while (1);
+	return 1;
+}
+
+static void event_worker(
+    Test_Event *test_events,
+    size_t test_event_count,
+    std::atomic<int> &condition ,
+    std::atomic<bool> *exit_flag,
+    int *filter_fdp, 
+    int *log_fdp
+)
+{
+    while(condition <= 0)
+    {
+        std::this_thread::sleep_for(std::chrono::microseconds(5));
+    }
+    if(condition != 1)
+    {
+        *exit_flag = true;
+        return;
+    }
+    auto filter_fd = *filter_fdp;
+    auto log_fd = *log_fdp;
+    for(size_t i = 0; i < test_event_count; ++i)
+    {
+        auto &e = test_events[i];
+		struct Buf buf = {};
+        if(rules_filter(filter_fd, e)){
+			if(add_buf_to_ringbuf(e, buf))
+			{
+                size_t len = strlen(buf.log);
+                if (len > 0)
+                {
+                    ring_buffer__push(log_fd, buf.log, len);
+                }
+			}
+        }    
+    }
+    condition = 2;
+	*exit_flag = true;
+}
+class TraceExecTest : public ::testing::Test
+{
+    protected:
+        void SetUp() override
+        {
+            createTestFiles();
+            memset(g_test_events, 0, sizeof(g_test_events));
+            g_test_event_count = 0;
+            g_condition = 0;
+            g_exit_flag = nullptr;
+        }
+        void TearDown() override
+        {
+            cleanTestFiles();
+        }
+        void createTestFiles()
+        {
+            system(("mkdir -p " + TEST_ROOT).c_str());
+        }
+        void cleanTestFiles()
+        {
+            system(("rm -rf " + TEST_ROOT).c_str());
+        }
+        bool existStr(const std::string &str)
+        {
+            std::ifstream file(TEST_LOG_FILE, std::ios::binary | std::ios::ate);
+            if(!file.is_open())
+            {
+                return false;
+            }
+            std::streamsize size = file.tellg();
+            file.seekg(0, std::ios::beg);
+            std::string content(size, '\0');
+            if(!file.read(&content[0],size)){
+                return false;
+            }
+            return content.find(str) != std::string::npos;
+        }
+          std::string readLog()
+        {
+            std::ifstream file(TEST_LOG_FILE, std::ios::binary | std::ios::ate);
+            if (!file.is_open())
+            {
+                return "";
+            }
+
+            std::streamsize size = file.tellg();
+            file.seekg(0, std::ios::beg);
+
+            std::string content(size, '\0');
+            if (!file.read(&content[0], size))
+            {
+                return "";
+            }
+            return content;
+        }
+        int countStr(const std::string &str)
+        {
+            std::ifstream file(TEST_LOG_FILE, std::ios::binary | std::ios::ate);
+            if(!file.is_open())
+            {
+                return false;
+            }
+            std::streamsize size = file.tellg();
+            file.seekg(0, std::ios::beg);
+            std::string content(size, '\0');
+            if(!file.read(&content[0],size)){
+                return false;
+            }
+            int count = 0;
+            size_t pos = 0;
+            while((pos = content.find(str, pos)) != std::string::npos) {
+                ++count;
+                pos += str.length();
+            }
+            return count;
+        }
+        // comm 和 pid 的数组顺序是，索引越大越靠近父节点
+        void addTestEvent(uint32_t uid, const char *path, const std::vector<std::string> &comm,const std::vector<pid_t> &pid){
+            ASSERT_LT(g_test_event_count, (size_t)TEST_EVENT_MAX);
+            auto &e = g_test_events[g_test_event_count++];
+            memset(&e, 0, sizeof(e));
+            e.uid = uid;
+            e.chain_len = std::min(comm.size(), pid.size());
+            if (e.chain_len > CHAIN_MAX_DEPTH)
+            {
+                e.chain_len = CHAIN_MAX_DEPTH;
+            }
+            if (path != nullptr) {
+                strncpy(e.path, path, sizeof(e.path) - 1);
+                e.path[sizeof(e.path) - 1] = '\0';
+            } else {
+                e.path[0] = '\0'; // 如果为空，设为空字符串
+            }
+            for (uint32_t i = 0; i < e.chain_len; ++i)
+            {
+                strncpy(e.comm[i], comm[i].c_str(), COMM_MAX_LEN - 1);
+                e.comm[i][COMM_MAX_LEN - 1] = '\0';
+                e.pid[i] = pid[i];
+            }
+        }
+        int runTraceExec(const std::vector<std::string> &_args){
+            g_condition = 0;
+            g_exit_flag = nullptr;
+            std::vector<std::string> t;
+            t.push_back("trace-exec");
+            t.insert(t.end(),_args.begin(), _args.end());
+            std::vector<char *> argv;
+            argv.reserve(t.size());
+            for(const auto &arg : t){
+                argv.push_back(const_cast<char *>(arg.c_str()));
+            }
+            argv.push_back(nullptr);
+            FILE *log_file = fopen(TEST_LOG_FILE.c_str(),"w");
+            int filter_fd, log_fd;
+            trace_exec_init(log_file, &g_condition ,&g_exit_flag, &filter_fd, &log_fd);
+            std::thread *event_theard = new std::thread(
+                event_worker,
+                g_test_events,
+                g_test_event_count,
+                std::ref(g_condition),
+                g_exit_flag,
+                &filter_fd,
+                &log_fd
+            );
+            int ret = trace_exec_main((int)t.size(), argv.data());
+            event_theard->join();
+            delete event_theard;
+            trace_exec_deinit();
+            fclose(log_file);
+            return ret;
+        }
+};
+TEST_F(TraceExecTest, SimpleTest1)
+{
+    runTraceExec({"-h"});
+    EXPECT_TRUE(existStr("Usage:"));
+    EXPECT_TRUE(!existStr("Tracing exec events... Hit Ctrl-C to end."));
+}
+TEST_F(TraceExecTest, SimpleTest2)
+{
+    addTestEvent(1, "/usr/bin/ls", {"ls", "bash", "deepin-terminal", "systemd", "systemd"},{2776242, 2776221, 2726957, 5082, 1});
+    runTraceExec({});
+    EXPECT_TRUE(existStr("Tracing exec events... Hit Ctrl-C to end."));
+    EXPECT_TRUE(existStr("ls(2776242)<-bash(2776221)<-deepin-terminal(2726957)<-systemd(5082)<-systemd(1)"));
+}
+//测试-u能否过滤成功
+TEST_F(TraceExecTest, UidFilterApplied)
+{
+    addTestEvent(1, "/usr/bin/ls", {"ls", "bash", "deepin-terminal", "systemd", "systemd"},{2776242, 2776221, 2726957, 5082, 1});
+    addTestEvent(2, "/usr/bin/tail", {"tail", "bash", "bash", "deepin-terminal", "systemd", "systemd"},{2881663, 2881661, 2881649, 2726957, 5082, 1});
+    runTraceExec({"-u","1"});
+    EXPECT_TRUE(existStr("Tracing exec events... Hit Ctrl-C to end."));
+    EXPECT_TRUE(existStr("ls(2776242)<-bash(2776221)<-deepin-terminal(2726957)<-systemd(5082)<-systemd(1)"));
+    EXPECT_TRUE(!existStr("tail(2881663)<-bash(2881661)<-bash(2881649)<-deepin-terminal(2726957)<-systemd(5082)<-systemd(1)")); 
+}
+//测试-t能否过滤成功
+TEST_F(TraceExecTest, TargetPathFilterApplied)
+{
+    addTestEvent(1, "/usr/bin/ls", {"ls", "bash", "deepin-terminal", "systemd", "systemd"},{2776242, 2776221, 2726957, 5082, 1});
+    addTestEvent(1, "/usr/bin/tail", {"tail", "bash", "bash", "deepin-terminal", "systemd", "systemd"},{2881663, 2881661, 2881649, 2726957, 5082, 1});
+    runTraceExec({"-t","/usr/bin/tail"});
+    EXPECT_TRUE(existStr("Tracing exec events... Hit Ctrl-C to end."));
+    EXPECT_TRUE(existStr("tail(2881663)<-bash(2881661)<-bash(2881649)<-deepin-terminal(2726957)<-systemd(5082)<-systemd(1)"));
+    EXPECT_TRUE(!existStr("ls(2776242)<-bash(2776221)<-deepin-terminal(2726957)<-systemd(5082)<-systemd(1)"));
+}
+//测试-d能否过滤成功
+TEST_F(TraceExecTest, DepthFilterApplied)
+{
+    addTestEvent(1, "/usr/bin/ls", {"ls", "bash", "deepin-terminal", "systemd", "systemd"},{2776242, 2776221, 2726957, 5082, 1});
+    addTestEvent(1, "/usr/bin/tail", {"tail", "bash", "bash", "deepin-terminal", "systemd", "systemd"},{2881663, 2881661, 2881649, 2726957, 5082, 1});
+    runTraceExec({"-d","2"});
+    EXPECT_TRUE(existStr("Tracing exec events... Hit Ctrl-C to end."));
+    EXPECT_TRUE(existStr("tail(2881663)<-bash(2881661)<-bash(2881649)<-deepin-terminal(2726957)"));
+    EXPECT_TRUE(existStr("ls(2776242)<-bash(2776221)<-deepin-terminal(2726957)<-systemd(5082)"));
+}
+//测试-d，-u能否组合过滤成功
+TEST_F(TraceExecTest, UidAndTargetCombinedFilterApplied)
+{
+    addTestEvent(1, "/usr/bin/ls", {"ls", "bash", "deepin-terminal", "systemd", "systemd"},{2776242, 2776221, 2726957, 5082, 1});
+    addTestEvent(2, "/usr/bin/tail", {"tail", "bash", "bash", "deepin-terminal", "systemd", "systemd"},{2881663, 2881661, 2881649, 2726957, 5082, 1});
+    runTraceExec({"-d","2", "-u", "1"});
+    EXPECT_TRUE(existStr("Tracing exec events... Hit Ctrl-C to end."));
+    EXPECT_TRUE(existStr("ls(2776242)<-bash(2776221)<-deepin-terminal(2726957)"));
+    EXPECT_TRUE(!existStr("tail(2881663)<-bash(2881661)<-bash(2881649)<-deepin-terminal(2726957)"));
+    EXPECT_TRUE(!existStr("tail(2881663)<-bash(2881661)<-bash(2881649)"));
+}
+//测试-u -1 异常数值能否被正确阻止，正确的uid正常被过滤
+TEST_F(TraceExecTest, InvalidUidRejectedtest1)
+{
+    addTestEvent(1, "/usr/bin/ls", {"ls", "bash", "deepin-terminal", "systemd", "systemd"},{2776242, 2776221, 2726957, 5082, 1});
+    addTestEvent(2, "/usr/bin/tail", {"tail", "bash", "bash", "deepin-terminal", "systemd", "systemd"},{2881663, 2881661, 2881649, 2726957, 5082, 1});
+    runTraceExec({"-u","1"});
+    EXPECT_TRUE(existStr("Tracing exec events... Hit Ctrl-C to end."));
+    EXPECT_TRUE(existStr("ls(2776242)<-bash(2776221)<-deepin-terminal(2726957)<-systemd(5082)<-systemd(1)"));
+    EXPECT_TRUE(!existStr("tail(2881663)<-bash(2881661)<-bash(2881649)<-deepin-terminal(2726957)<-systemd(5082)<-systemd(1)")); 
+    runTraceExec({"-u","-1"});
+    EXPECT_TRUE(existStr("wrong uid value: -1, must be a non-negative integer"));
+}
+//测试-u 12abc 异常数值能否被正确阻止，正确的uid正常被过滤
+TEST_F(TraceExecTest, InvalidUidRejectedtest2)
+{
+    addTestEvent(1, "/usr/bin/ls", {"ls", "bash", "deepin-terminal", "systemd", "systemd"},{2776242, 2776221, 2726957, 5082, 1});
+    addTestEvent(2, "/usr/bin/tail", {"tail", "bash", "bash", "deepin-terminal", "systemd", "systemd"},{2881663, 2881661, 2881649, 2726957, 5082, 1});
+    runTraceExec({"-u","1"});
+    EXPECT_TRUE(existStr("Tracing exec events... Hit Ctrl-C to end."));
+    EXPECT_TRUE(existStr("ls(2776242)<-bash(2776221)<-deepin-terminal(2726957)<-systemd(5082)<-systemd(1)"));
+    EXPECT_TRUE(!existStr("tail(2881663)<-bash(2881661)<-bash(2881649)<-deepin-terminal(2726957)<-systemd(5082)<-systemd(1)")); 
+    runTraceExec({"-u","12abc"});
+    EXPECT_TRUE(existStr("wrong uid value: 12abc, must be a non-negative integer"));
+}
+//测试-d -1 异常数值能否被正确阻止，正确的depth正常起作用
+TEST_F(TraceExecTest, InvalidDepthRejectedtest1)
+{
+    addTestEvent(1, "/usr/bin/ls", {"ls", "bash", "deepin-terminal", "systemd", "systemd"},{2776242, 2776221, 2726957, 5082, 1});
+    addTestEvent(2, "/usr/bin/tail", {"tail", "bash", "bash", "deepin-terminal", "systemd", "systemd"},{2881663, 2881661, 2881649, 2726957, 5082, 1});
+    runTraceExec({"-d","1"});
+    EXPECT_TRUE(existStr("Tracing exec events... Hit Ctrl-C to end."));
+    EXPECT_TRUE(existStr("ls(2776242)<-bash(2776221)<-deepin-terminal(2726957)"));
+    EXPECT_TRUE(existStr("tail(2881663)<-bash(2881661)<-bash(2881649)")); 
+    runTraceExec({"-d","-1"});
+    EXPECT_TRUE(existStr("wrong depth value: -1, must be a positive integer"));
+}
+//测试-d 0 异常数值能否被正确阻止，正确的depth正常起作用
+TEST_F(TraceExecTest, InvalidDepthRejectedtest2)
+{
+    addTestEvent(1, "/usr/bin/ls", {"ls", "bash", "deepin-terminal", "systemd", "systemd"},{2776242, 2776221, 2726957, 5082, 1});
+    addTestEvent(2, "/usr/bin/tail", {"tail", "bash", "bash", "deepin-terminal", "systemd", "systemd"},{2881663, 2881661, 2881649, 2726957, 5082, 1});
+    runTraceExec({"-d","1"});
+    EXPECT_TRUE(existStr("Tracing exec events... Hit Ctrl-C to end."));
+    EXPECT_TRUE(existStr("ls(2776242)<-bash(2776221)<-deepin-terminal(2726957)"));
+    EXPECT_TRUE(existStr("tail(2881663)<-bash(2881661)<-bash(2881649)")); 
+    runTraceExec({"-d","0"});
+    EXPECT_TRUE(existStr("wrong depth value: 0, must be a positive integer"));
+}
+//测试-d 12a 异常数值能否被正确阻止，正确的depth正常起作用
+TEST_F(TraceExecTest, InvalidDepthRejectedtest3)
+{
+    addTestEvent(1, "/usr/bin/ls", {"ls", "bash", "deepin-terminal", "systemd", "systemd"},{2776242, 2776221, 2726957, 5082, 1});
+    addTestEvent(2, "/usr/bin/tail", {"tail", "bash", "bash", "deepin-terminal", "systemd", "systemd"},{2881663, 2881661, 2881649, 2726957, 5082, 1});
+    runTraceExec({"-d","1"});
+    EXPECT_TRUE(existStr("Tracing exec events... Hit Ctrl-C to end."));
+    EXPECT_TRUE(existStr("ls(2776242)<-bash(2776221)<-deepin-terminal(2726957)"));
+    EXPECT_TRUE(existStr("tail(2881663)<-bash(2881661)<-bash(2881649)")); 
+    runTraceExec({"-d","12a"});
+    EXPECT_TRUE(existStr("wrong depth value: 12a, must be a positive integer"));
+}
+//测试-u 超大数值能否被正确阻止，正确的uid正常起作用
+TEST_F(TraceExecTest, InvalidUidOverflowRejected)
+{
+    addTestEvent(1, "/usr/bin/ls", {"ls", "bash", "deepin-terminal", "systemd", "systemd"},{2776242, 2776221, 2726957, 5082, 1});
+    addTestEvent(2, "/usr/bin/tail", {"tail", "bash", "bash", "deepin-terminal", "systemd", "systemd"},{2881663, 2881661, 2881649, 2726957, 5082, 1});
+    runTraceExec({"-u","1"});
+    EXPECT_TRUE(existStr("Tracing exec events... Hit Ctrl-C to end."));
+    EXPECT_TRUE(existStr("ls(2776242)<-bash(2776221)<-deepin-terminal(2726957)<-systemd(5082)<-systemd(1)"));
+    EXPECT_TRUE(!existStr("tail(2881663)<-bash(2881661)<-bash(2881649)<-deepin-terminal(2726957)<-systemd(5082)<-systemd(1)")); 
+    runTraceExec({"-u","7000000000000000000000"});
+    EXPECT_TRUE(existStr("wrong uid value: 7000000000000000000000, must be a non-negative integer"));
+}


### PR DESCRIPTION
### 本次修改集中在 test 目录，修改内容如下

1. 添加了 trace-exec 的 BUILTIN 单测。测试内容围绕工具实际功能补充了较完整的回归验证，覆盖了以下几类行为：

    - 简单功能测试
    - 测试-u能否过滤成功
    - 测试-t能否过滤成功
    - 测试-d能否过滤成功
    - 测试-d，-u能否组合过滤成功
    - 测试-u -1 异常数值能否被正确阻止，正确的uid正常被过滤
    - 测试-u 12abc 异常数值能否被正确阻止，正确的uid正常被过滤
    - 测试-d -1 异常数值能否被正确阻止，正确的depth正常起作用
    - 测试-d 0 异常数值能否被正确阻止，正确的depth正常起作用
    - 测试-d 12a 异常数值能否被正确阻止，正确的depth正常起作用
    - 测试-u 超大数值能否被正确阻止，正确的uid正常起作用

2. 在test/Makefile 中补齐测试目标的链接依赖；
3. 在test/mock.cpp 中修正 skeleton 对象在全局容器中的分配、指针回填和销毁逻辑，避免因扩容和错索引导致的崩溃；
