### PR TITLE
test: add trace-signal testing and builtin coverage for trace-signal …

### DIFF
--- a/test/Makefile
+++ b/test/Makefile
@@ -23,7 +23,8 @@ CXXFLAGS = -g -D__GTEST__ -DBUILTIN -MMD \
 		   -I$(PROJ_ROOT)/build/policy \
 		   -I$(PROJ_ROOT)/bpf/export
 
-LDFLAGS = -Wl,-rpath=$(PROJ_ROOT)/googletest/build/lib/
+LDFLAGS = -Wl,-rpath='$$ORIGIN/../../googletest/build/lib'
+LDLIBS = -lbpf -lpthread -lelf -lz
 
 GTEST_LIBS = $(PROJ_ROOT)/googletest/build/lib/libgtest_main.so	\
 			 $(PROJ_ROOT)/googletest/build/lib/libgtest.so
@@ -43,9 +44,10 @@ $(TARGET): $(OBJS) $(GTEST_LIBS) \
 	$(BUILD_DIR)/kmemleak.o \
 	$(BUILD_DIR)/irqsnoop.o \
 	$(BUILD_DIR)/mountsnoop.o \
+	$(BUILD_DIR)/trace-signal.o \
 	$(BUILD_DIR)/frtp.o \
 	$(BUILD_DIR)/elfverify.o
-	$(CXX) $^ $(LDFLAGS) -o $@
+	$(CXX) $^ $(LDFLAGS) $(LDLIBS) -o $@
 
 $(BUILD_DIR):
 	@mkdir -p $@

--- a/test/mock.cpp
+++ b/test/mock.cpp
@@ -68,6 +68,7 @@ struct bpf_map
 	size_t value_size;
 	size_t max_entries;
 	size_t sz;
+	size_t mmap_sz;
 	void *mem;
 	bpf_map_type type;
 	std::string name;
@@ -81,6 +82,15 @@ struct bpf_object
 	std::vector<bpf_link> links;
 };
 
+struct skeleton_offsets
+{
+	size_t map_base;
+	size_t prog_base;
+	size_t link_base;
+	int map_cnt;
+	int prog_cnt;
+};
+
 struct ring_buffer
 {
 	int map_fd;
@@ -90,6 +100,7 @@ struct ring_buffer
 };
 
 static bpf_object g_obj;
+static std::map<const bpf_object_skeleton *, skeleton_offsets> g_skeleton_offsets;
 
 std::string fd_path(int fd)
 {
@@ -293,22 +304,52 @@ void bpf_object__destroy_skeleton(struct bpf_object_skeleton *s)
 		return;
 	}
 
-	int fd;
-	char buf[PATH_MAX];
-
-	for (int i = 0; i < s->prog_cnt; i++)
+	auto offset_it = g_skeleton_offsets.find(s);
+	if (offset_it == g_skeleton_offsets.end())
 	{
-		close(g_obj.progs[i].fd);
-		close(g_obj.links[i].fd);
+		free(s->maps);
+		free(s->progs);
+		free(s);
+		return;
 	}
-	g_obj.progs.clear();
-	g_obj.links.clear();
+	const skeleton_offsets offsets = offset_it->second;
+
 	for (int i = 0; i < s->map_cnt; i++)
 	{
-		munmap(g_obj.maps[i].mem, g_obj.maps[i].sz);
-		close(g_obj.maps[i].fd);
+		if (s->maps[i].mmaped && *s->maps[i].mmaped)
+		{
+			free(*s->maps[i].mmaped);
+			*s->maps[i].mmaped = nullptr;
+		}
 	}
-	g_obj.maps.clear();
+
+	for (int i = 0; i < offsets.prog_cnt; i++)
+	{
+		close(g_obj.progs[offsets.prog_base + i].fd);
+		close(g_obj.links[offsets.link_base + i].fd);
+	}
+	g_obj.progs.erase(
+		g_obj.progs.begin() + offsets.prog_base,
+		g_obj.progs.begin() + offsets.prog_base + offsets.prog_cnt
+	);
+	g_obj.links.erase(
+		g_obj.links.begin() + offsets.link_base,
+		g_obj.links.begin() + offsets.link_base + offsets.prog_cnt
+	);
+	for (int i = 0; i < offsets.map_cnt; i++)
+	{
+		bpf_map &map = g_obj.maps[offsets.map_base + i];
+		if (map.mem)
+		{
+			munmap(map.mem, map.mmap_sz ? map.mmap_sz : map.sz);
+		}
+		close(map.fd);
+	}
+	g_obj.maps.erase(
+		g_obj.maps.begin() + offsets.map_base,
+		g_obj.maps.begin() + offsets.map_base + offsets.map_cnt
+	);
+	g_skeleton_offsets.erase(offset_it);
 	free(s->maps);
 	free(s->progs);
 	free(s);
@@ -319,7 +360,7 @@ int bpf_object__find_map_fd_by_name(
 	const char *name
 )
 {
-	for (int i = 0; i < obj->maps.size(); i++)
+	for (int i = (int)obj->maps.size() - 1; i >= 0; i--)
 	{
 		if (obj->maps[i].name == name)
 		{
@@ -345,15 +386,21 @@ int bpf_object__open_skeleton(
 
 	*s->obj = &g_obj;
 
+	const size_t map_base = g_obj.maps.size();
+	const size_t prog_base = g_obj.progs.size();
+	const size_t link_base = g_obj.links.size();
+	g_obj.maps.reserve(map_base + s->map_cnt);
+	g_obj.progs.reserve(prog_base + s->prog_cnt);
+	g_obj.links.reserve(link_base + s->prog_cnt);
+	g_skeleton_offsets[s] = {map_base, prog_base, link_base, s->map_cnt, s->prog_cnt};
+
 	int fd;
-	bpf_program prog;
-	bpf_map map;
-	bpf_link link;
 	const char *name;
 	char buf[PATH_MAX];
 
 	for (int i = 0; i < s->map_cnt; i++)
 	{
+		bpf_map map {};
 		name = s->maps[i].name;
 		snprintf(buf, PATH_MAX, "%s/map-%s", BPF_PIN_PATH, name);
 		fd = open(buf, O_RDWR | O_TRUNC | O_CREAT, 0600);
@@ -378,35 +425,43 @@ int bpf_object__open_skeleton(
 			map.sz = RB_MAP_SIZE;
 			map.type = BPF_MAP_TYPE_UNSPEC;
 		}
+		map.mmap_sz = 0;
 		int page_size = getpagesize();
 		if (strcmp(name, "dk_shared_mem") == 0 ||
 			map.type == BPF_MAP_TYPE_RINGBUF)
 		{
 			int ret = 0;
-			ret = ftruncate(fd, page_size * 2 + RB_MAP_SIZE);
+			map.mmap_sz = page_size * 2 + RB_MAP_SIZE;
+			ret = ftruncate(fd, map.mmap_sz);
 			assert(ret == 0);
 			map.type = BPF_MAP_TYPE_RINGBUF;
 			map.mem = mmap(
 				NULL,
-				page_size * 2 + RB_MAP_SIZE,
+				map.mmap_sz,
 				PROT_READ | PROT_WRITE,
 				MAP_SHARED,
 				fd,
 				0
 			);
 			assert(map.mem != MAP_FAILED);
-			memset(map.mem, 0, page_size * 2 + RB_MAP_SIZE);
+			memset(map.mem, 0, map.mmap_sz);
 		}
 		else
 		{
 			map.mem = nullptr;
 		}
 		g_obj.maps.push_back(std::move(map));
-		*s->maps[i].map = &g_obj.maps[i];
+		*s->maps[i].map = &g_obj.maps[map_base + i];
+		if (s->maps[i].mmaped)
+		{
+			*s->maps[i].mmaped = calloc(1, getpagesize());
+			assert(*s->maps[i].mmaped != nullptr);
+		}
 	}
 
 	for (int i = 0; i < s->prog_cnt; i++)
 	{
+		bpf_program prog {};
 		name = s->progs[i].name;
 		snprintf(buf, PATH_MAX, "%s/prog-%s", BPF_PIN_PATH, name);
 		fd = open(buf, O_RDWR | O_TRUNC | O_CREAT, 0600);
@@ -432,8 +487,9 @@ int bpf_object__open_skeleton(
 			}
 		}
 		g_obj.progs.push_back(std::move(prog));
-		*s->progs[i].prog = &g_obj.progs[i];
+		*s->progs[i].prog = &g_obj.progs[prog_base + i];
 
+		bpf_link link {};
 		snprintf(buf, PATH_MAX, "%s/link-%s", BPF_PIN_PATH, name);
 		fd = open(buf, O_RDWR | O_TRUNC | O_CREAT, 0600);
 		if (fd < 0)
@@ -442,9 +498,9 @@ int bpf_object__open_skeleton(
 		}
 		link.fd = fd;
 		link.pin_path = buf;
-		link.prog = &g_obj.progs[i];
+		link.prog = &g_obj.progs[prog_base + i];
 		g_obj.links.push_back(std::move(link));
-		*s->progs[i].link = &g_obj.links[i];
+		*s->progs[i].link = &g_obj.links[link_base + i];
 	}
 	return 0;
 }

--- a/test/trace-signal-test.cpp
+++ b/test/trace-signal-test.cpp
@@ -1,0 +1,444 @@
+// SPDX-FileCopyrightText: 2025 UnionTech Software Technology Co., Ltd
+//
+// SPDX-License-Identifier: LGPL-2.1
+
+// This file uses/derives from googletest
+// Copyright 2008, Google Inc.
+// Licensed under the BSD 3-Clause License
+// See NOTICE for full license text
+
+#include "gtest/gtest.h"
+#include "jhash.h"
+
+#include <atomic>
+#include <bpf/bpf.h>
+#include <cstdio>
+#include <filesystem>
+#include <fstream>
+#include <string>
+#include <thread>
+#include <vector>
+
+struct TraceSignalRule
+{
+	int32_t sender_pid;
+	uint32_t sender_phash;
+	int32_t recv_pid;
+	uint32_t recv_phash;
+	int32_t sig;
+	int32_t res;
+};
+
+struct TraceSignalLog
+{
+	int32_t sender_pid;
+	char sender_comm[16];
+	int32_t recv_pid;
+	char recv_comm[16];
+	int32_t sig;
+	int32_t res;
+};
+
+extern void trace_signal_init(
+	FILE *output,
+	std::atomic<int> *conditionp,
+	std::atomic<bool> **exit_flagp,
+	int *filter_fd,
+	int *log_fd
+);
+extern void trace_signal_deinit();
+extern int trace_signal_emit_log(const void *log, size_t data_sz);
+extern int trace_signal_submit_builtin_event(
+	const void *log,
+	size_t data_sz,
+	uint32_t sender_phash,
+	uint32_t recv_phash
+);
+extern void trace_signal_get_rule_copy(void *out, size_t out_sz);
+extern int trace_signal_main(int argc, char **argv);
+
+namespace
+{
+struct SimulatedEvent
+{
+	TraceSignalLog log {};
+	uint32_t sender_phash = 0;
+	uint32_t recv_phash = 0;
+};
+
+struct WorkerCapture
+{
+	TraceSignalRule rule {};
+};
+
+uint32_t programHash(const std::string &program)
+{
+	std::vector<u32> words(4096 / sizeof(u32), 0);
+	char *buf = reinterpret_cast<char *>(words.data());
+	strncpy(buf, program.c_str(), 4096 - 1);
+	return jhash2(words.data(), words.size(), 0);
+}
+
+bool waitForSubstring(
+	const std::string &path,
+	const std::vector<std::string> &needles,
+	int timeout_ms
+)
+{
+	for (int waited = 0; waited < timeout_ms; waited += 10)
+	{
+		std::ifstream file(path, std::ios::binary);
+		std::string content(
+			(std::istreambuf_iterator<char>(file)),
+			std::istreambuf_iterator<char>()
+		);
+		bool matched = true;
+		for (const auto &needle : needles)
+		{
+			if (content.find(needle) == std::string::npos)
+			{
+				matched = false;
+				break;
+			}
+		}
+		if (matched)
+		{
+			return true;
+		}
+		std::this_thread::sleep_for(std::chrono::milliseconds(10));
+	}
+	return false;
+}
+}
+
+class TraceSignalBuiltinTest : public ::testing::Test
+{
+  protected:
+	const std::string test_root = "/tmp/trace_signal_test_dir";
+	const std::string log_file_path = test_root + "/trace_signal.log";
+
+	void SetUp() override
+	{
+		std::filesystem::create_directories(test_root);
+	}
+
+	void TearDown() override
+	{
+		std::error_code ec;
+		std::filesystem::remove_all(test_root, ec);
+	}
+
+	std::string readLog() const
+	{
+		std::ifstream file(log_file_path, std::ios::binary);
+		if (!file.is_open())
+		{
+			return "";
+		}
+		return std::string(
+			(std::istreambuf_iterator<char>(file)),
+			std::istreambuf_iterator<char>()
+		);
+	}
+
+	int runTraceSignal(
+		const std::vector<std::string> &tool_args,
+		const std::vector<SimulatedEvent> &events,
+		WorkerCapture *capture = nullptr
+	)
+	{
+		std::vector<std::string> args;
+		args.reserve(tool_args.size() + 1);
+		args.push_back("trace-signal");
+		args.insert(args.end(), tool_args.begin(), tool_args.end());
+
+		std::vector<char *> argv;
+		argv.reserve(args.size() + 1);
+		for (const auto &arg : args)
+		{
+			argv.push_back(const_cast<char *>(arg.c_str()));
+		}
+		argv.push_back(nullptr);
+
+		FILE *log_file = fopen(log_file_path.c_str(), "w");
+		EXPECT_NE(log_file, nullptr);
+		if (!log_file)
+		{
+			return -1;
+		}
+
+		std::atomic<int> condition = 0;
+		std::atomic<bool> *exit_flag = nullptr;
+		trace_signal_init(
+			log_file,
+			&condition,
+			&exit_flag,
+			nullptr,
+			nullptr
+		);
+		int ret = -999;
+		std::thread tool_thread(
+			[&]()
+			{
+				ret =
+					trace_signal_main(static_cast<int>(argv.size() - 1), argv.data());
+			}
+		);
+
+		while (condition <= 0)
+		{
+			std::this_thread::sleep_for(std::chrono::microseconds(50));
+		}
+		if (condition == 1)
+		{
+			if (capture)
+			{
+				trace_signal_get_rule_copy(&capture->rule, sizeof(capture->rule));
+			}
+
+			for (const auto &event : events)
+			{
+				if (trace_signal_submit_builtin_event(
+						&event.log,
+						sizeof(event.log),
+						event.sender_phash,
+						event.recv_phash
+					) != 0)
+				{
+					ret = -1;
+				}
+			}
+			*exit_flag = true;
+		}
+
+		tool_thread.join();
+		trace_signal_deinit();
+		fclose(log_file);
+		return ret;
+	}
+};
+
+TEST_F(TraceSignalBuiltinTest, HelpOptionPrintsUsage)
+{
+	EXPECT_EQ(runTraceSignal({"-h"}, {}), 0);
+	const std::string content = readLog();
+	EXPECT_NE(content.find("Usage: trace-signal"), std::string::npos);
+	EXPECT_NE(content.find("--sender-pid"), std::string::npos);
+	EXPECT_NE(content.find("--recv-pid"), std::string::npos);
+	EXPECT_NE(content.find("--sender-prog"), std::string::npos);
+	EXPECT_NE(content.find("--recv-prog"), std::string::npos);
+	EXPECT_NE(content.find("--sig"), std::string::npos);
+	EXPECT_NE(content.find("--res"), std::string::npos);
+}
+
+TEST_F(TraceSignalBuiltinTest, InvalidOptionReturnsError)
+{
+	EXPECT_LT(runTraceSignal({"--bad-option"}, {}), 0);
+	EXPECT_NE(readLog().find("Usage: trace-signal"), std::string::npos);
+}
+
+TEST_F(TraceSignalBuiltinTest, LoadsRuleAndPrintsLogs)
+{
+	WorkerCapture capture;
+	SimulatedEvent matched = {};
+	matched.log.sender_pid = 101;
+	snprintf(matched.log.sender_comm, sizeof(matched.log.sender_comm), "bash");
+	matched.log.recv_pid = 202;
+	snprintf(matched.log.recv_comm, sizeof(matched.log.recv_comm), "sleep");
+	matched.log.sig = 15;
+	matched.log.res = 0;
+
+	SimulatedEvent wrong_sender = matched;
+	wrong_sender.log.sender_pid = 999;
+	snprintf(wrong_sender.log.sender_comm, sizeof(wrong_sender.log.sender_comm), "other");
+
+	SimulatedEvent wrong_recv = matched;
+	wrong_recv.log.recv_pid = 303;
+	snprintf(wrong_recv.log.recv_comm, sizeof(wrong_recv.log.recv_comm), "otherrecv");
+
+	SimulatedEvent wrong_sig = matched;
+	wrong_sig.log.sig = 9;
+
+	SimulatedEvent wrong_res = matched;
+	wrong_res.log.res = -1;
+
+	ASSERT_EQ(
+		runTraceSignal(
+			{"--sender-pid", "101", "--recv-pid", "202", "--sig", "15", "--res", "0"},
+			{matched, wrong_sender, wrong_recv, wrong_sig, wrong_res},
+			&capture
+		),
+		0
+	);
+
+	EXPECT_EQ(capture.rule.sender_pid, 101);
+	EXPECT_EQ(capture.rule.recv_pid, 202);
+	EXPECT_EQ(capture.rule.sig, 15);
+	EXPECT_EQ(capture.rule.res, 0);
+
+	std::string output = readLog();
+	EXPECT_NE(output.find("bash"), std::string::npos);
+	EXPECT_NE(output.find("sleep"), std::string::npos);
+	EXPECT_NE(output.find("Terminated"), std::string::npos);
+	EXPECT_EQ(output.find("other"), std::string::npos);
+	EXPECT_EQ(output.find("otherrecv"), std::string::npos);
+}
+
+TEST_F(TraceSignalBuiltinTest, DefaultRuleValuesAreApplied)
+{
+	WorkerCapture capture;
+	ASSERT_EQ(runTraceSignal({}, {}, &capture), 0);
+
+	EXPECT_EQ(capture.rule.sender_pid, 0);
+	EXPECT_EQ(capture.rule.sender_phash, 0u);
+	EXPECT_EQ(capture.rule.recv_pid, 0);
+	EXPECT_EQ(capture.rule.recv_phash, 0u);
+	EXPECT_EQ(capture.rule.sig, 0);
+	EXPECT_EQ(capture.rule.res, 0);
+}
+
+TEST_F(TraceSignalBuiltinTest, SenderProgramFilterOnlyEmitsMatchingSenderProgram)
+{
+	WorkerCapture capture;
+	SimulatedEvent matched = {};
+	matched.log.sender_pid = 101;
+	snprintf(matched.log.sender_comm, sizeof(matched.log.sender_comm), "bash");
+	matched.log.recv_pid = 202;
+	snprintf(matched.log.recv_comm, sizeof(matched.log.recv_comm), "sleep");
+	matched.log.sig = 15;
+	matched.sender_phash = programHash("/usr/bin/bash");
+
+	SimulatedEvent wrong_sender_prog = matched;
+	snprintf(
+		wrong_sender_prog.log.sender_comm,
+		sizeof(wrong_sender_prog.log.sender_comm),
+		"python"
+	);
+	wrong_sender_prog.sender_phash = programHash("/usr/bin/python3");
+
+	ASSERT_EQ(
+		runTraceSignal(
+			{
+				"--sender-pid",
+				"101",
+				"--recv-pid",
+				"202",
+				"--sender-prog",
+				"/usr/bin/bash"
+			},
+			{matched, wrong_sender_prog},
+			&capture
+		),
+		0
+	);
+
+	EXPECT_EQ(capture.rule.sender_pid, 101);
+	EXPECT_EQ(capture.rule.recv_pid, 202);
+	EXPECT_EQ(capture.rule.sender_phash, programHash("/usr/bin/bash"));
+	EXPECT_EQ(capture.rule.recv_phash, 0u);
+	EXPECT_EQ(capture.rule.sig, 0);
+	EXPECT_EQ(capture.rule.res, 0);
+
+	const std::string output = readLog();
+	EXPECT_NE(output.find("bash"), std::string::npos);
+	EXPECT_EQ(output.find("python"), std::string::npos);
+}
+
+TEST_F(TraceSignalBuiltinTest, SenderAndReceiverProgramFiltersBothApply)
+{
+	WorkerCapture capture;
+	SimulatedEvent matched = {};
+	matched.log.sender_pid = 101;
+	snprintf(matched.log.sender_comm, sizeof(matched.log.sender_comm), "bash");
+	matched.log.recv_pid = 202;
+	snprintf(matched.log.recv_comm, sizeof(matched.log.recv_comm), "sleep");
+	matched.log.sig = 15;
+	matched.sender_phash = programHash("/usr/bin/bash");
+	matched.recv_phash = programHash("/usr/bin/sleep");
+
+	SimulatedEvent wrong_recv_prog = matched;
+	snprintf(
+		wrong_recv_prog.log.recv_comm,
+		sizeof(wrong_recv_prog.log.recv_comm),
+		"cat"
+	);
+	wrong_recv_prog.recv_phash = programHash("/usr/bin/cat");
+
+	SimulatedEvent wrong_sender_prog = matched;
+	snprintf(
+		wrong_sender_prog.log.sender_comm,
+		sizeof(wrong_sender_prog.log.sender_comm),
+		"python"
+	);
+	wrong_sender_prog.sender_phash = programHash("/usr/bin/python3");
+
+	ASSERT_EQ(
+		runTraceSignal(
+			{
+				"--sender-pid",
+				"101",
+				"--recv-pid",
+				"202",
+				"--sender-prog",
+				"/usr/bin/bash",
+				"--recv-prog",
+				"/usr/bin/sleep",
+				"--sig",
+				"15"
+			},
+			{matched, wrong_recv_prog, wrong_sender_prog},
+			&capture
+		),
+		0
+	);
+
+	EXPECT_EQ(capture.rule.sender_pid, 101);
+	EXPECT_EQ(capture.rule.recv_pid, 202);
+	EXPECT_EQ(capture.rule.sender_phash, programHash("/usr/bin/bash"));
+	EXPECT_EQ(capture.rule.recv_phash, programHash("/usr/bin/sleep"));
+	EXPECT_EQ(capture.rule.sig, 15);
+	EXPECT_EQ(capture.rule.res, 0);
+
+	const std::string output = readLog();
+	EXPECT_NE(output.find("bash"), std::string::npos);
+	EXPECT_NE(output.find("sleep"), std::string::npos);
+	EXPECT_EQ(output.find("python"), std::string::npos);
+	EXPECT_EQ(output.find("cat"), std::string::npos);
+}
+
+TEST_F(TraceSignalBuiltinTest, DefaultRuleValuesAllowMultipleEvents)
+{
+	WorkerCapture capture;
+	SimulatedEvent first = {};
+	first.log.sender_pid = 11;
+	snprintf(first.log.sender_comm, sizeof(first.log.sender_comm), "bash");
+	first.log.recv_pid = 22;
+	snprintf(first.log.recv_comm, sizeof(first.log.recv_comm), "sleep");
+	first.log.sig = 15;
+	first.log.res = 0;
+
+	SimulatedEvent second = {};
+	second.log.sender_pid = 33;
+	snprintf(second.log.sender_comm, sizeof(second.log.sender_comm), "python");
+	second.log.recv_pid = 44;
+	snprintf(second.log.recv_comm, sizeof(second.log.recv_comm), "cat");
+	second.log.sig = 9;
+	second.log.res = -1;
+
+	ASSERT_EQ(runTraceSignal({}, {first, second}, &capture), 0);
+
+	EXPECT_EQ(capture.rule.sender_pid, 0);
+	EXPECT_EQ(capture.rule.sender_phash, 0u);
+	EXPECT_EQ(capture.rule.recv_pid, 0);
+	EXPECT_EQ(capture.rule.recv_phash, 0u);
+	EXPECT_EQ(capture.rule.sig, 0);
+	EXPECT_EQ(capture.rule.res, 0);
+
+	EXPECT_TRUE(
+		waitForSubstring(
+			log_file_path,
+			{"bash", "sleep", "python", "cat"},
+			500
+		)
+	);
+}


### PR DESCRIPTION
### 本次修改集中在 test 目录，修改内容如下

1. 添加了 trace-signal 的 BUILTIN 单测。测试内容围绕 trace-signal 的实际功能补充了回归验证，覆盖了帮助输出（验证 -h/--help 能正常打印 usage，并包含 sender-pid、recv-pid、sender-prog、recv-prog、sig、res 等选项说明）、非法参数处理（验证传入非法选项时，返回错误，并输出 usage）、自定义规则解析与过滤语义（验证 sender-pid、recv-pid、sender-prog、recv-prog、sig、res 规则能够正确解析，并且只有匹配规则的 signal 事件会输出，不匹配事件会被过滤）、默认规则解析（验证未传参时规则字段保持默认值，且默认不过滤时可输出多条不同事件）、以及日志输出格式化（验证输出中包含 sender pid、sender comm、receiver pid、receiver comm、signal 文本和 result 字段）这几类关键行为。
2. 在test/Makefile 中补齐测试目标的链接依赖；
3. 在test/mock.cpp 中修正 skeleton 对象在全局容器中的分配、指针回填和销毁逻辑，避免因扩容和错索引导致的崩溃；