### PR TITLE
test: add peek-fd testing and builtin coverage for peek-fd tool

### DIFF
--- a/test/Makefile
+++ b/test/Makefile
@@ -23,7 +23,8 @@ CXXFLAGS = -g -D__GTEST__ -DBUILTIN -MMD \
 		   -I$(PROJ_ROOT)/build/policy \
 		   -I$(PROJ_ROOT)/bpf/export
 
-LDFLAGS = -Wl,-rpath=$(PROJ_ROOT)/googletest/build/lib/
+LDFLAGS = -Wl,-rpath='$$ORIGIN/../../googletest/build/lib'
+LDLIBS = -lbpf -lpthread -lelf -lz
 
 GTEST_LIBS = $(PROJ_ROOT)/googletest/build/lib/libgtest_main.so	\
 			 $(PROJ_ROOT)/googletest/build/lib/libgtest.so
@@ -43,9 +44,10 @@ $(TARGET): $(OBJS) $(GTEST_LIBS) \
 	$(BUILD_DIR)/kmemleak.o \
 	$(BUILD_DIR)/irqsnoop.o \
 	$(BUILD_DIR)/mountsnoop.o \
+	$(BUILD_DIR)/peek-fd.o \
 	$(BUILD_DIR)/frtp.o \
 	$(BUILD_DIR)/elfverify.o
-	$(CXX) $^ $(LDFLAGS) -o $@
+	$(CXX) $^ $(LDFLAGS) $(LDLIBS) -o $@
 
 $(BUILD_DIR):
 	@mkdir -p $@

--- a/test/mock.cpp
+++ b/test/mock.cpp
@@ -68,6 +68,7 @@ struct bpf_map
 	size_t value_size;
 	size_t max_entries;
 	size_t sz;
+	size_t mmap_sz;
 	void *mem;
 	bpf_map_type type;
 	std::string name;
@@ -81,6 +82,15 @@ struct bpf_object
 	std::vector<bpf_link> links;
 };
 
+struct skeleton_offsets
+{
+	size_t map_base;
+	size_t prog_base;
+	size_t link_base;
+	int map_cnt;
+	int prog_cnt;
+};
+
 struct ring_buffer
 {
 	int map_fd;
@@ -90,6 +100,7 @@ struct ring_buffer
 };
 
 static bpf_object g_obj;
+static std::map<const bpf_object_skeleton *, skeleton_offsets> g_skeleton_offsets;
 
 std::string fd_path(int fd)
 {
@@ -293,22 +304,52 @@ void bpf_object__destroy_skeleton(struct bpf_object_skeleton *s)
 		return;
 	}
 
-	int fd;
-	char buf[PATH_MAX];
-
-	for (int i = 0; i < s->prog_cnt; i++)
+	auto offset_it = g_skeleton_offsets.find(s);
+	if (offset_it == g_skeleton_offsets.end())
 	{
-		close(g_obj.progs[i].fd);
-		close(g_obj.links[i].fd);
+		free(s->maps);
+		free(s->progs);
+		free(s);
+		return;
 	}
-	g_obj.progs.clear();
-	g_obj.links.clear();
+	const skeleton_offsets offsets = offset_it->second;
+
 	for (int i = 0; i < s->map_cnt; i++)
 	{
-		munmap(g_obj.maps[i].mem, g_obj.maps[i].sz);
-		close(g_obj.maps[i].fd);
+		if (s->maps[i].mmaped && *s->maps[i].mmaped)
+		{
+			free(*s->maps[i].mmaped);
+			*s->maps[i].mmaped = nullptr;
+		}
 	}
-	g_obj.maps.clear();
+
+	for (int i = 0; i < offsets.prog_cnt; i++)
+	{
+		close(g_obj.progs[offsets.prog_base + i].fd);
+		close(g_obj.links[offsets.link_base + i].fd);
+	}
+	g_obj.progs.erase(
+		g_obj.progs.begin() + offsets.prog_base,
+		g_obj.progs.begin() + offsets.prog_base + offsets.prog_cnt
+	);
+	g_obj.links.erase(
+		g_obj.links.begin() + offsets.link_base,
+		g_obj.links.begin() + offsets.link_base + offsets.prog_cnt
+	);
+	for (int i = 0; i < offsets.map_cnt; i++)
+	{
+		bpf_map &map = g_obj.maps[offsets.map_base + i];
+		if (map.mem)
+		{
+			munmap(map.mem, map.mmap_sz ? map.mmap_sz : map.sz);
+		}
+		close(map.fd);
+	}
+	g_obj.maps.erase(
+		g_obj.maps.begin() + offsets.map_base,
+		g_obj.maps.begin() + offsets.map_base + offsets.map_cnt
+	);
+	g_skeleton_offsets.erase(offset_it);
 	free(s->maps);
 	free(s->progs);
 	free(s);
@@ -319,7 +360,7 @@ int bpf_object__find_map_fd_by_name(
 	const char *name
 )
 {
-	for (int i = 0; i < obj->maps.size(); i++)
+	for (int i = (int)obj->maps.size() - 1; i >= 0; i--)
 	{
 		if (obj->maps[i].name == name)
 		{
@@ -345,15 +386,21 @@ int bpf_object__open_skeleton(
 
 	*s->obj = &g_obj;
 
+	const size_t map_base = g_obj.maps.size();
+	const size_t prog_base = g_obj.progs.size();
+	const size_t link_base = g_obj.links.size();
+	g_obj.maps.reserve(map_base + s->map_cnt);
+	g_obj.progs.reserve(prog_base + s->prog_cnt);
+	g_obj.links.reserve(link_base + s->prog_cnt);
+	g_skeleton_offsets[s] = {map_base, prog_base, link_base, s->map_cnt, s->prog_cnt};
+
 	int fd;
-	bpf_program prog;
-	bpf_map map;
-	bpf_link link;
 	const char *name;
 	char buf[PATH_MAX];
 
 	for (int i = 0; i < s->map_cnt; i++)
 	{
+		bpf_map map {};
 		name = s->maps[i].name;
 		snprintf(buf, PATH_MAX, "%s/map-%s", BPF_PIN_PATH, name);
 		fd = open(buf, O_RDWR | O_TRUNC | O_CREAT, 0600);
@@ -378,35 +425,43 @@ int bpf_object__open_skeleton(
 			map.sz = RB_MAP_SIZE;
 			map.type = BPF_MAP_TYPE_UNSPEC;
 		}
+		map.mmap_sz = 0;
 		int page_size = getpagesize();
 		if (strcmp(name, "dk_shared_mem") == 0 ||
 			map.type == BPF_MAP_TYPE_RINGBUF)
 		{
 			int ret = 0;
-			ret = ftruncate(fd, page_size * 2 + RB_MAP_SIZE);
+			map.mmap_sz = page_size * 2 + RB_MAP_SIZE;
+			ret = ftruncate(fd, map.mmap_sz);
 			assert(ret == 0);
 			map.type = BPF_MAP_TYPE_RINGBUF;
 			map.mem = mmap(
 				NULL,
-				page_size * 2 + RB_MAP_SIZE,
+				map.mmap_sz,
 				PROT_READ | PROT_WRITE,
 				MAP_SHARED,
 				fd,
 				0
 			);
 			assert(map.mem != MAP_FAILED);
-			memset(map.mem, 0, page_size * 2 + RB_MAP_SIZE);
+			memset(map.mem, 0, map.mmap_sz);
 		}
 		else
 		{
 			map.mem = nullptr;
 		}
 		g_obj.maps.push_back(std::move(map));
-		*s->maps[i].map = &g_obj.maps[i];
+		*s->maps[i].map = &g_obj.maps[map_base + i];
+		if (s->maps[i].mmaped)
+		{
+			*s->maps[i].mmaped = calloc(1, getpagesize());
+			assert(*s->maps[i].mmaped != nullptr);
+		}
 	}
 
 	for (int i = 0; i < s->prog_cnt; i++)
 	{
+		bpf_program prog {};
 		name = s->progs[i].name;
 		snprintf(buf, PATH_MAX, "%s/prog-%s", BPF_PIN_PATH, name);
 		fd = open(buf, O_RDWR | O_TRUNC | O_CREAT, 0600);
@@ -432,8 +487,9 @@ int bpf_object__open_skeleton(
 			}
 		}
 		g_obj.progs.push_back(std::move(prog));
-		*s->progs[i].prog = &g_obj.progs[i];
+		*s->progs[i].prog = &g_obj.progs[prog_base + i];
 
+		bpf_link link {};
 		snprintf(buf, PATH_MAX, "%s/link-%s", BPF_PIN_PATH, name);
 		fd = open(buf, O_RDWR | O_TRUNC | O_CREAT, 0600);
 		if (fd < 0)
@@ -442,9 +498,9 @@ int bpf_object__open_skeleton(
 		}
 		link.fd = fd;
 		link.pin_path = buf;
-		link.prog = &g_obj.progs[i];
+		link.prog = &g_obj.progs[prog_base + i];
 		g_obj.links.push_back(std::move(link));
-		*s->progs[i].link = &g_obj.links[i];
+		*s->progs[i].link = &g_obj.links[link_base + i];
 	}
 	return 0;
 }

--- a/test/peek-fd-test.cpp
+++ b/test/peek-fd-test.cpp
@@ -1,0 +1,369 @@
+// SPDX-FileCopyrightText: 2025 UnionTech Software Technology Co., Ltd
+//
+// SPDX-License-Identifier: LGPL-2.1
+
+// This file uses/derives from googletest
+// Copyright 2008, Google Inc.
+// Licensed under the BSD 3-Clause License
+// See NOTICE for full license text
+
+#include "gtest/gtest.h"
+
+#include <atomic>
+#include <cstdio>
+#include <cstring>
+#include <filesystem>
+#include <fstream>
+#include <string>
+#include <thread>
+#include <vector>
+
+struct PeekFdRule
+{
+	int32_t pid;
+	int32_t fd;
+	int32_t rw;
+};
+
+struct PeekFdLog
+{
+	ssize_t sz;
+	char buf[];
+};
+
+extern void peek_fd_init(
+	FILE *output,
+	std::atomic<int> *conditionp,
+	std::atomic<bool> **exit_flagp,
+	int *filter_fd_out,
+	int *log_fd_out
+);
+extern void peek_fd_deinit();
+extern void peek_fd_get_rule_copy(void *out, size_t out_sz);
+extern bool peek_fd_get_sock_trace_enabled();
+extern bool peek_fd_get_read_trace_selected();
+extern bool peek_fd_get_write_trace_selected();
+extern int peek_fd_submit_builtin_event(
+	int32_t pid,
+	int32_t fd,
+	int32_t rw,
+	bool is_socket,
+	const char *payload
+);
+extern int peek_fd_main(int argc, char **argv);
+
+namespace
+{
+constexpr int kFdRead = 1;
+constexpr int kFdWrite = 2;
+
+struct WorkerCapture
+{
+	PeekFdRule rule {};
+	bool sock_trace_enabled = false;
+	bool read_trace_selected = false;
+	bool write_trace_selected = false;
+};
+
+struct SimulatedEvent
+{
+	int32_t pid;
+	int32_t fd;
+	int32_t rw;
+	bool is_socket;
+	std::string payload;
+};
+}
+
+class PeekFdBuiltinTest : public ::testing::Test
+{
+  protected:
+	const std::string test_root = "/tmp/peek_fd_test_dir";
+	const std::string log_file_path = test_root + "/peek_fd.log";
+	const std::string out_file_path = test_root + "/peek_fd.out";
+
+	void SetUp() override
+	{
+		std::filesystem::create_directories(test_root);
+	}
+
+	void TearDown() override
+	{
+		std::error_code ec;
+		std::filesystem::remove_all(test_root, ec);
+	}
+
+	std::string readFile(const std::string &path) const
+	{
+		std::ifstream file(path, std::ios::binary);
+		if (!file.is_open())
+		{
+			return "";
+		}
+		return std::string(
+			(std::istreambuf_iterator<char>(file)),
+			std::istreambuf_iterator<char>()
+		);
+	}
+
+	int runPeekFd(
+		const std::vector<std::string> &tool_args,
+		const std::vector<SimulatedEvent> &events,
+		WorkerCapture *capture = nullptr
+	)
+	{
+		std::vector<std::string> args;
+		args.reserve(tool_args.size() + 1);
+		args.push_back("peek-fd");
+		args.insert(args.end(), tool_args.begin(), tool_args.end());
+
+		std::vector<char *> argv;
+		argv.reserve(args.size() + 1);
+		for (const auto &arg : args)
+		{
+			argv.push_back(const_cast<char *>(arg.c_str()));
+		}
+		argv.push_back(nullptr);
+
+		FILE *log_file = fopen(log_file_path.c_str(), "w");
+		EXPECT_NE(log_file, nullptr);
+		if (!log_file)
+		{
+			return -1;
+		}
+
+		std::atomic<int> condition = 0;
+		std::atomic<bool> *exit_flag = nullptr;
+		int worker_error = 0;
+		peek_fd_init(log_file, &condition, &exit_flag, nullptr, nullptr);
+
+		int ret = -999;
+		std::thread tool_thread(
+			[&]()
+			{
+				ret = peek_fd_main(static_cast<int>(argv.size() - 1), argv.data());
+			}
+		);
+
+		while (condition <= 0)
+		{
+			std::this_thread::sleep_for(std::chrono::microseconds(5));
+		}
+		if (condition == 1)
+		{
+			if (capture)
+			{
+				peek_fd_get_rule_copy(&capture->rule, sizeof(capture->rule));
+				capture->sock_trace_enabled = peek_fd_get_sock_trace_enabled();
+				capture->read_trace_selected = peek_fd_get_read_trace_selected();
+				capture->write_trace_selected = peek_fd_get_write_trace_selected();
+			}
+
+			for (const auto &event : events)
+			{
+				if (peek_fd_submit_builtin_event(
+						event.pid,
+						event.fd,
+						event.rw,
+						event.is_socket,
+						event.payload.c_str()
+					) != 0)
+				{
+					worker_error = -1;
+					break;
+				}
+			}
+			condition = 2;
+			*exit_flag = true;
+		}
+
+		tool_thread.join();
+		peek_fd_deinit();
+		fclose(log_file);
+		if (worker_error != 0)
+		{
+			return worker_error;
+		}
+		return ret;
+	}
+};
+
+TEST_F(PeekFdBuiltinTest, HelpOptionPrintsUsage)
+{
+	EXPECT_EQ(runPeekFd({"-h"}, {}), 0);
+	const std::string content = readFile(log_file_path);
+	EXPECT_NE(content.find("Usage: peek-fd"), std::string::npos);
+	EXPECT_NE(content.find("--pid"), std::string::npos);
+	EXPECT_NE(content.find("--fd"), std::string::npos);
+	EXPECT_NE(content.find("--outfile"), std::string::npos);
+	EXPECT_NE(content.find("--sock"), std::string::npos);
+}
+
+TEST_F(PeekFdBuiltinTest, InvalidOptionReturnsError)
+{
+	EXPECT_LT(runPeekFd({"--bad-option"}, {}), 0);
+	EXPECT_NE(readFile(log_file_path).find("Usage: peek-fd"), std::string::npos);
+}
+
+TEST_F(PeekFdBuiltinTest, MissingPidOrFdReturnsError)
+{
+	EXPECT_LT(runPeekFd({"--pid", "123", "--read"}, {}), 0);
+	EXPECT_NE(
+		readFile(log_file_path).find(
+			"You need to specify which process and which fd"
+		),
+		std::string::npos
+	);
+}
+
+TEST_F(PeekFdBuiltinTest, MissingReadWriteModeReturnsError)
+{
+	EXPECT_LT(runPeekFd({"--pid", "123", "--fd", "8"}, {}), 0);
+	EXPECT_NE(
+		readFile(log_file_path).find(
+			"You need to specify at least one of option -r/-w"
+		),
+		std::string::npos
+	);
+}
+
+TEST_F(PeekFdBuiltinTest, ReadModeLoadsRuleAndOnlyLogsMatchingReadEvents)
+{
+	WorkerCapture capture;
+	ASSERT_EQ(
+		runPeekFd(
+			{"--pid", "321", "--fd", "9", "--read"},
+			{
+				{321, 9, kFdRead, false, "matched-read"},
+				{321, 9, kFdWrite, false, "wrong-mode"},
+				{999, 9, kFdRead, false, "wrong-pid"},
+				{321, 10, kFdRead, false, "wrong-fd"},
+			},
+			&capture
+		),
+		0
+	);
+
+	EXPECT_EQ(capture.rule.pid, 321);
+	EXPECT_EQ(capture.rule.fd, 9);
+	EXPECT_EQ(capture.rule.rw, kFdRead);
+	EXPECT_FALSE(capture.sock_trace_enabled);
+	EXPECT_TRUE(capture.read_trace_selected);
+	EXPECT_FALSE(capture.write_trace_selected);
+
+	const std::string content = readFile(log_file_path);
+	EXPECT_NE(content.find("matched-read"), std::string::npos);
+	EXPECT_EQ(content.find("wrong-mode"), std::string::npos);
+	EXPECT_EQ(content.find("wrong-pid"), std::string::npos);
+	EXPECT_EQ(content.find("wrong-fd"), std::string::npos);
+}
+
+TEST_F(PeekFdBuiltinTest, WriteModeLoadsRuleAndOnlyLogsMatchingWriteEvents)
+{
+	WorkerCapture capture;
+	ASSERT_EQ(
+		runPeekFd(
+			{"--pid", "456", "--fd", "10", "--write"},
+			{
+				{456, 10, kFdWrite, false, "matched-write"},
+				{456, 10, kFdRead, false, "wrong-mode"},
+				{456, 11, kFdWrite, false, "wrong-fd"},
+			},
+			&capture
+		),
+		0
+	);
+
+	EXPECT_EQ(capture.rule.pid, 456);
+	EXPECT_EQ(capture.rule.fd, 10);
+	EXPECT_EQ(capture.rule.rw, kFdWrite);
+	EXPECT_FALSE(capture.sock_trace_enabled);
+	EXPECT_FALSE(capture.read_trace_selected);
+	EXPECT_TRUE(capture.write_trace_selected);
+
+	const std::string content = readFile(log_file_path);
+	EXPECT_NE(content.find("matched-write"), std::string::npos);
+	EXPECT_EQ(content.find("wrong-mode"), std::string::npos);
+	EXPECT_EQ(content.find("wrong-fd"), std::string::npos);
+}
+
+TEST_F(PeekFdBuiltinTest, ReadWriteAndSockModesLogAllSelectedEvents)
+{
+	WorkerCapture capture;
+	ASSERT_EQ(
+		runPeekFd(
+			{"--pid", "789", "--fd", "11", "--read", "--write", "--sock"},
+			{
+				{789, 11, kFdRead, false, "plain-read"},
+				{789, 11, kFdWrite, false, "plain-write"},
+				{789, 11, kFdRead, true, "socket-read"},
+				{789, 11, kFdWrite, true, "socket-write"},
+				{789, 11, kFdRead | kFdWrite, false, "rw-combined"},
+			},
+			&capture
+		),
+		0
+	);
+
+	EXPECT_EQ(capture.rule.pid, 789);
+	EXPECT_EQ(capture.rule.fd, 11);
+	EXPECT_EQ(capture.rule.rw, kFdRead | kFdWrite);
+	EXPECT_TRUE(capture.sock_trace_enabled);
+	EXPECT_TRUE(capture.read_trace_selected);
+	EXPECT_TRUE(capture.write_trace_selected);
+
+	const std::string content = readFile(log_file_path);
+	EXPECT_NE(content.find("plain-read"), std::string::npos);
+	EXPECT_NE(content.find("plain-write"), std::string::npos);
+	EXPECT_NE(content.find("socket-read"), std::string::npos);
+	EXPECT_NE(content.find("socket-write"), std::string::npos);
+	EXPECT_NE(content.find("rw-combined"), std::string::npos);
+}
+
+TEST_F(PeekFdBuiltinTest, SocketEventsRequireSockOption)
+{
+	ASSERT_EQ(
+		runPeekFd(
+			{"--pid", "901", "--fd", "7", "--read"},
+			{
+				{901, 7, kFdRead, true, "socket-read"},
+				{901, 7, kFdRead, false, "plain-read"},
+			}
+		),
+		0
+	);
+
+	const std::string content = readFile(log_file_path);
+	EXPECT_NE(content.find("plain-read"), std::string::npos);
+	EXPECT_EQ(content.find("socket-read"), std::string::npos);
+}
+
+TEST_F(PeekFdBuiltinTest, DefaultOutputPrintsMatchedLogsToCurrentStdout)
+{
+	ASSERT_EQ(
+		runPeekFd(
+			{"--pid", "100", "--fd", "12", "--read"},
+			{{100, 12, kFdRead, false, "stdout-data"}}
+		),
+		0
+	);
+	EXPECT_NE(readFile(log_file_path).find("stdout-data"), std::string::npos);
+}
+
+TEST_F(PeekFdBuiltinTest, OutfileRedirectsMatchedLogsToFile)
+{
+	ASSERT_EQ(
+		runPeekFd(
+			{"--pid", "200", "--fd", "13", "--write", "--outfile", out_file_path},
+			{
+				{200, 13, kFdWrite, false, "outfile-data"},
+				{200, 14, kFdWrite, false, "wrong-fd"},
+			}
+		),
+		0
+	);
+
+	EXPECT_NE(readFile(out_file_path).find("outfile-data"), std::string::npos);
+	EXPECT_EQ(readFile(out_file_path).find("wrong-fd"), std::string::npos);
+	EXPECT_EQ(readFile(log_file_path).find("outfile-data"), std::string::npos);
+}


### PR DESCRIPTION
### 本次修改集中在 test 目录，修改内容如下

1. 添加了 peek-fd 的 BUILTIN 单测。测试内容围绕工具实际功能补充了较完整的回归验证，覆盖了以下几类行为：
    - 帮助信息输出：验证 -h/--help 能正常打印 usage，并包含 pid、fd、read、write、outfile、sock 等选项说明。
    - 非法参数处理：验证传入非法选项时会返回错误，并输出 usage，保证参数校验路径正确。
    - 必选参数校验：验证缺少 pid / fd 时会报错，缺少 read / write 模式时也会报错，确保工具使用约束正确。
    - 默认输出行为：验证未指定 --outfile 时，匹配到的 FD 数据会写到当前标准输出。
    - 输出重定向行为：验证指定 --outfile 后，匹配数据会写入目标文件，不会误写回默认输出文件。
    - read 过滤语义：验证只开启 --read 时，仅匹配读事件，写事件、错误 pid、错误 fd 事件都会被过滤。
    - write 过滤语义：验证只开启 --write 时，仅匹配写事件，读事件和错误 fd 事件都会被过滤。
    - read + write 联合语义：验证同时开启 --read --write 时，读写两类事件都能正常输出。
    - sock 过滤语义：验证只有显式开启 --sock 时，socket 类型 FD 事件才会输出；未开启时，普通 FD 事件仍可输出，但 socket 事件会被过滤。
    - 多条件组合过滤：验证 pid、fd、read/write、sock 多个条件组合后，只有真正满足全部条件的事件会输出。
    - 日志输出行为：验证匹配规则的 FD 数据会真正写入输出，不匹配事件不会误输出，确保过滤结果和最终日志一致。
2. 在test/Makefile 中补齐测试目标的链接依赖；
3. 在test/mock.cpp 中修正 skeleton 对象在全局容器中的分配、指针回填和销毁逻辑，避免因扩容和错索引导致的崩溃；