### PR TITLE
test: add lsof testing and builtin coverage for lsof tool

### DIFF
--- a/test/Makefile
+++ b/test/Makefile
@@ -23,7 +23,8 @@ CXXFLAGS = -g -D__GTEST__ -DBUILTIN -MMD \
 		   -I$(PROJ_ROOT)/build/policy \
 		   -I$(PROJ_ROOT)/bpf/export
 
-LDFLAGS = -Wl,-rpath=$(PROJ_ROOT)/googletest/build/lib/
+LDFLAGS = -Wl,-rpath='$$ORIGIN/../../googletest/build/lib'
+LDLIBS = -lbpf -lpthread -lelf -lz
 
 GTEST_LIBS = $(PROJ_ROOT)/googletest/build/lib/libgtest_main.so	\
 			 $(PROJ_ROOT)/googletest/build/lib/libgtest.so
@@ -39,13 +40,14 @@ all: $(TARGET)
 
 $(TARGET): $(OBJS) $(GTEST_LIBS) \
 	$(BUILD_DIR)/trace-file.o \
+	$(BUILD_DIR)/lsof.o \
 	$(BUILD_DIR)/lsock.o \
 	$(BUILD_DIR)/kmemleak.o \
 	$(BUILD_DIR)/irqsnoop.o \
 	$(BUILD_DIR)/mountsnoop.o \
 	$(BUILD_DIR)/frtp.o \
 	$(BUILD_DIR)/elfverify.o
-	$(CXX) $^ $(LDFLAGS) -o $@
+	$(CXX) $^ $(LDFLAGS) $(LDLIBS) -o $@
 
 $(BUILD_DIR):
 	@mkdir -p $@

--- a/test/lsof-test.cpp
+++ b/test/lsof-test.cpp
@@ -1,0 +1,329 @@
+// SPDX-FileCopyrightText: 2025 UnionTech Software Technology Co., Ltd
+//
+// SPDX-License-Identifier: LGPL-2.1
+
+// This file uses/derives from googletest
+// Copyright 2008, Google Inc.
+// Licensed under the BSD 3-Clause License
+// See NOTICE for full license text
+
+#include "gtest/gtest.h"
+
+#include <atomic>
+#include <cstdio>
+#include <cstring>
+#include <filesystem>
+#include <fstream>
+#include <string>
+#include <thread>
+#include <vector>
+
+namespace
+{
+constexpr size_t kPathMax = 4096;
+}
+
+union LsofRule
+{
+	char path[kPathMax];
+	struct
+	{
+		uint64_t not_inode;
+		uint64_t inode;
+		uint64_t dev;
+	};
+};
+
+struct LsofLog
+{
+	uint32_t uid;
+	int32_t pid;
+	int32_t fd;
+	char comm[16];
+};
+
+struct SimulatedEvent
+{
+	LsofLog log {};
+	std::string path;
+	uint64_t dev = 0;
+	uint64_t inode = 0;
+};
+
+extern void lsof_init(
+	FILE *output,
+	std::atomic<int> *conditionp,
+	std::atomic<bool> **exit_flagp
+);
+extern void lsof_deinit();
+extern void lsof_get_rule_copy(void *out, size_t out_sz);
+extern int lsof_submit_builtin_event(
+	const void *log,
+	size_t data_sz,
+	const char *path,
+	dev_t dev,
+	uint64_t inode
+);
+extern int lsof_main(int argc, char **argv);
+
+namespace
+{
+struct WorkerCapture
+{
+	LsofRule rule {};
+};
+
+bool waitForSubstring(
+	const std::string &path,
+	const std::vector<std::string> &needles,
+	int timeout_ms
+)
+{
+	for (int waited = 0; waited < timeout_ms; waited += 10)
+	{
+		std::ifstream file(path, std::ios::binary);
+		std::string content(
+			(std::istreambuf_iterator<char>(file)),
+			std::istreambuf_iterator<char>()
+		);
+		bool matched = true;
+		for (const auto &needle : needles)
+		{
+			if (content.find(needle) == std::string::npos)
+			{
+				matched = false;
+				break;
+			}
+		}
+		if (matched)
+		{
+			return true;
+		}
+		std::this_thread::sleep_for(std::chrono::milliseconds(10));
+	}
+	return false;
+}
+}
+
+class LsofBuiltinTest : public ::testing::Test
+{
+  protected:
+	const std::string test_root = "/tmp/lsof_test_dir";
+	const std::string log_file_path = test_root + "/lsof.log";
+
+	void SetUp() override
+	{
+		std::filesystem::create_directories(test_root);
+	}
+
+	void TearDown() override
+	{
+		std::error_code ec;
+		std::filesystem::remove_all(test_root, ec);
+	}
+
+	std::string readLog() const
+	{
+		std::ifstream file(log_file_path, std::ios::binary);
+		if (!file.is_open())
+		{
+			return "";
+		}
+		return std::string(
+			(std::istreambuf_iterator<char>(file)),
+			std::istreambuf_iterator<char>()
+		);
+	}
+
+	int runLsof(
+		const std::vector<std::string> &tool_args,
+		const std::vector<SimulatedEvent> &events,
+		WorkerCapture *capture = nullptr
+	)
+	{
+		std::vector<std::string> args;
+		args.reserve(tool_args.size() + 1);
+		args.push_back("lsof");
+		args.insert(args.end(), tool_args.begin(), tool_args.end());
+
+		std::vector<char *> argv;
+		argv.reserve(args.size() + 1);
+		for (const auto &arg : args)
+		{
+			argv.push_back(const_cast<char *>(arg.c_str()));
+		}
+		argv.push_back(nullptr);
+
+		FILE *log_file = fopen(log_file_path.c_str(), "w");
+		EXPECT_NE(log_file, nullptr);
+		if (!log_file)
+		{
+			return -1;
+		}
+
+		std::atomic<int> condition = 0;
+		std::atomic<bool> *exit_flag = nullptr;
+		lsof_init(log_file, &condition, &exit_flag);
+		int ret = -999;
+		std::thread tool_thread(
+			[&]()
+			{
+				ret = lsof_main(static_cast<int>(argv.size() - 1), argv.data());
+			}
+		);
+
+		while (condition <= 0)
+		{
+			std::this_thread::sleep_for(std::chrono::microseconds(50));
+		}
+		if (condition == 1)
+		{
+			if (capture)
+			{
+				lsof_get_rule_copy(&capture->rule, sizeof(capture->rule));
+			}
+
+			for (const auto &event : events)
+			{
+				if (lsof_submit_builtin_event(
+						&event.log,
+						sizeof(event.log),
+						event.path.c_str(),
+						static_cast<dev_t>(event.dev),
+						event.inode
+					) != 0)
+				{
+					ret = -1;
+				}
+			}
+			*exit_flag = true;
+		}
+
+		tool_thread.join();
+		lsof_deinit();
+		fclose(log_file);
+		return ret;
+	}
+};
+
+TEST_F(LsofBuiltinTest, HelpOptionPrintsUsage)
+{
+	EXPECT_EQ(runLsof({"-h"}, {}), 0);
+	const std::string content = readLog();
+	EXPECT_NE(content.find("Usage: lsof"), std::string::npos);
+	EXPECT_NE(content.find("--path"), std::string::npos);
+	EXPECT_NE(content.find("--dev"), std::string::npos);
+	EXPECT_NE(content.find("--inode"), std::string::npos);
+	EXPECT_NE(content.find("--help"), std::string::npos);
+}
+
+TEST_F(LsofBuiltinTest, InvalidOptionReturnsError)
+{
+	EXPECT_LT(runLsof({"--bad-option"}, {}), 0);
+	EXPECT_NE(readLog().find("Usage: lsof"), std::string::npos);
+}
+
+TEST_F(LsofBuiltinTest, PathAndInodeCannotBeUsedTogether)
+{
+	EXPECT_LT(
+		runLsof({"--path", "/tmp/a", "--inode", "123", "--dev", "456"}, {}),
+		0
+	);
+	EXPECT_NE(
+		readLog().find("error: -p and -i can't be used together"),
+		std::string::npos
+	);
+}
+
+TEST_F(LsofBuiltinTest, DevAndInodeMustBeUsedTogether)
+{
+	EXPECT_LT(runLsof({"--dev", "123"}, {}), 0);
+	EXPECT_NE(
+		readLog().find("error: -d and -i must be used together"),
+		std::string::npos
+	);
+}
+
+TEST_F(LsofBuiltinTest, PathRuleAggregatesMatchedFileAndVmaEntries)
+{
+	WorkerCapture capture;
+	SimulatedEvent fd3 = {};
+	fd3.log.uid = 1000;
+	fd3.log.pid = 321;
+	fd3.log.fd = 3;
+	snprintf(fd3.log.comm, sizeof(fd3.log.comm), "bash");
+	fd3.path = "/tmp/target";
+
+	SimulatedEvent fd5 = fd3;
+	fd5.log.fd = 5;
+
+	SimulatedEvent vma = fd3;
+	vma.log.fd = -1;
+
+	SimulatedEvent other = fd3;
+	other.log.pid = 999;
+	snprintf(other.log.comm, sizeof(other.log.comm), "other");
+	other.path = "/tmp/other";
+
+	ASSERT_EQ(
+		runLsof({"--path", "/tmp/target"}, {fd3, fd5, vma, other}, &capture),
+		0
+	);
+
+	EXPECT_STREQ(capture.rule.path, "/tmp/target");
+	const std::string content = readLog();
+	EXPECT_TRUE(
+		waitForSubstring(
+			log_file_path,
+			{"COMM", "UID", "PID", "FD", "bash", "1000", "321", "3", "5", "vma(1)"},
+			500
+		)
+	);
+	EXPECT_EQ(content.find("other"), std::string::npos);
+}
+
+TEST_F(LsofBuiltinTest, DevAndInodeRuleOnlyEmitsMatchedEntries)
+{
+	WorkerCapture capture;
+	SimulatedEvent matched = {};
+	matched.log.uid = 2000;
+	matched.log.pid = 456;
+	matched.log.fd = 8;
+	snprintf(matched.log.comm, sizeof(matched.log.comm), "python");
+	matched.dev = 12345;
+	matched.inode = 67890;
+
+	SimulatedEvent wrong_dev = matched;
+	wrong_dev.dev = 12346;
+
+	SimulatedEvent wrong_inode = matched;
+	wrong_inode.inode = 67891;
+
+	ASSERT_EQ(
+		runLsof(
+			{"--dev", "12345", "--inode", "67890"},
+			{matched, wrong_dev, wrong_inode},
+			&capture
+		),
+		0
+	);
+
+	EXPECT_EQ(capture.rule.not_inode, 0u);
+	EXPECT_EQ(capture.rule.dev, 12345u);
+	EXPECT_EQ(capture.rule.inode, 67890u);
+	const std::string content = readLog();
+	EXPECT_TRUE(
+		waitForSubstring(log_file_path, {"python", "2000", "456", "8"}, 500)
+	);
+}
+
+TEST_F(LsofBuiltinTest, DefaultRuleValuesAreZeroed)
+{
+	WorkerCapture capture;
+	ASSERT_EQ(runLsof({}, {}, &capture), 0);
+	EXPECT_EQ(capture.rule.not_inode, 0u);
+	EXPECT_EQ(capture.rule.dev, 0u);
+	EXPECT_EQ(capture.rule.inode, 0u);
+	EXPECT_EQ(capture.rule.path[0], '\0');
+	EXPECT_TRUE(waitForSubstring(log_file_path, {"COMM", "UID", "PID", "FD"}, 500));
+}

--- a/test/mock.cpp
+++ b/test/mock.cpp
@@ -68,6 +68,7 @@ struct bpf_map
 	size_t value_size;
 	size_t max_entries;
 	size_t sz;
+	size_t mmap_sz;
 	void *mem;
 	bpf_map_type type;
 	std::string name;
@@ -81,6 +82,15 @@ struct bpf_object
 	std::vector<bpf_link> links;
 };
 
+struct skeleton_offsets
+{
+	size_t map_base;
+	size_t prog_base;
+	size_t link_base;
+	int map_cnt;
+	int prog_cnt;
+};
+
 struct ring_buffer
 {
 	int map_fd;
@@ -90,6 +100,7 @@ struct ring_buffer
 };
 
 static bpf_object g_obj;
+static std::map<const bpf_object_skeleton *, skeleton_offsets> g_skeleton_offsets;
 
 std::string fd_path(int fd)
 {
@@ -293,22 +304,52 @@ void bpf_object__destroy_skeleton(struct bpf_object_skeleton *s)
 		return;
 	}
 
-	int fd;
-	char buf[PATH_MAX];
-
-	for (int i = 0; i < s->prog_cnt; i++)
+	auto offset_it = g_skeleton_offsets.find(s);
+	if (offset_it == g_skeleton_offsets.end())
 	{
-		close(g_obj.progs[i].fd);
-		close(g_obj.links[i].fd);
+		free(s->maps);
+		free(s->progs);
+		free(s);
+		return;
 	}
-	g_obj.progs.clear();
-	g_obj.links.clear();
+	const skeleton_offsets offsets = offset_it->second;
+
 	for (int i = 0; i < s->map_cnt; i++)
 	{
-		munmap(g_obj.maps[i].mem, g_obj.maps[i].sz);
-		close(g_obj.maps[i].fd);
+		if (s->maps[i].mmaped && *s->maps[i].mmaped)
+		{
+			free(*s->maps[i].mmaped);
+			*s->maps[i].mmaped = nullptr;
+		}
 	}
-	g_obj.maps.clear();
+
+	for (int i = 0; i < offsets.prog_cnt; i++)
+	{
+		close(g_obj.progs[offsets.prog_base + i].fd);
+		close(g_obj.links[offsets.link_base + i].fd);
+	}
+	g_obj.progs.erase(
+		g_obj.progs.begin() + offsets.prog_base,
+		g_obj.progs.begin() + offsets.prog_base + offsets.prog_cnt
+	);
+	g_obj.links.erase(
+		g_obj.links.begin() + offsets.link_base,
+		g_obj.links.begin() + offsets.link_base + offsets.prog_cnt
+	);
+	for (int i = 0; i < offsets.map_cnt; i++)
+	{
+		bpf_map &map = g_obj.maps[offsets.map_base + i];
+		if (map.mem)
+		{
+			munmap(map.mem, map.mmap_sz ? map.mmap_sz : map.sz);
+		}
+		close(map.fd);
+	}
+	g_obj.maps.erase(
+		g_obj.maps.begin() + offsets.map_base,
+		g_obj.maps.begin() + offsets.map_base + offsets.map_cnt
+	);
+	g_skeleton_offsets.erase(offset_it);
 	free(s->maps);
 	free(s->progs);
 	free(s);
@@ -319,7 +360,7 @@ int bpf_object__find_map_fd_by_name(
 	const char *name
 )
 {
-	for (int i = 0; i < obj->maps.size(); i++)
+	for (int i = (int)obj->maps.size() - 1; i >= 0; i--)
 	{
 		if (obj->maps[i].name == name)
 		{
@@ -345,15 +386,21 @@ int bpf_object__open_skeleton(
 
 	*s->obj = &g_obj;
 
+	const size_t map_base = g_obj.maps.size();
+	const size_t prog_base = g_obj.progs.size();
+	const size_t link_base = g_obj.links.size();
+	g_obj.maps.reserve(map_base + s->map_cnt);
+	g_obj.progs.reserve(prog_base + s->prog_cnt);
+	g_obj.links.reserve(link_base + s->prog_cnt);
+	g_skeleton_offsets[s] = {map_base, prog_base, link_base, s->map_cnt, s->prog_cnt};
+
 	int fd;
-	bpf_program prog;
-	bpf_map map;
-	bpf_link link;
 	const char *name;
 	char buf[PATH_MAX];
 
 	for (int i = 0; i < s->map_cnt; i++)
 	{
+		bpf_map map {};
 		name = s->maps[i].name;
 		snprintf(buf, PATH_MAX, "%s/map-%s", BPF_PIN_PATH, name);
 		fd = open(buf, O_RDWR | O_TRUNC | O_CREAT, 0600);
@@ -378,35 +425,43 @@ int bpf_object__open_skeleton(
 			map.sz = RB_MAP_SIZE;
 			map.type = BPF_MAP_TYPE_UNSPEC;
 		}
+		map.mmap_sz = 0;
 		int page_size = getpagesize();
 		if (strcmp(name, "dk_shared_mem") == 0 ||
 			map.type == BPF_MAP_TYPE_RINGBUF)
 		{
 			int ret = 0;
-			ret = ftruncate(fd, page_size * 2 + RB_MAP_SIZE);
+			map.mmap_sz = page_size * 2 + RB_MAP_SIZE;
+			ret = ftruncate(fd, map.mmap_sz);
 			assert(ret == 0);
 			map.type = BPF_MAP_TYPE_RINGBUF;
 			map.mem = mmap(
 				NULL,
-				page_size * 2 + RB_MAP_SIZE,
+				map.mmap_sz,
 				PROT_READ | PROT_WRITE,
 				MAP_SHARED,
 				fd,
 				0
 			);
 			assert(map.mem != MAP_FAILED);
-			memset(map.mem, 0, page_size * 2 + RB_MAP_SIZE);
+			memset(map.mem, 0, map.mmap_sz);
 		}
 		else
 		{
 			map.mem = nullptr;
 		}
 		g_obj.maps.push_back(std::move(map));
-		*s->maps[i].map = &g_obj.maps[i];
+		*s->maps[i].map = &g_obj.maps[map_base + i];
+		if (s->maps[i].mmaped)
+		{
+			*s->maps[i].mmaped = calloc(1, getpagesize());
+			assert(*s->maps[i].mmaped != nullptr);
+		}
 	}
 
 	for (int i = 0; i < s->prog_cnt; i++)
 	{
+		bpf_program prog {};
 		name = s->progs[i].name;
 		snprintf(buf, PATH_MAX, "%s/prog-%s", BPF_PIN_PATH, name);
 		fd = open(buf, O_RDWR | O_TRUNC | O_CREAT, 0600);
@@ -432,8 +487,9 @@ int bpf_object__open_skeleton(
 			}
 		}
 		g_obj.progs.push_back(std::move(prog));
-		*s->progs[i].prog = &g_obj.progs[i];
+		*s->progs[i].prog = &g_obj.progs[prog_base + i];
 
+		bpf_link link {};
 		snprintf(buf, PATH_MAX, "%s/link-%s", BPF_PIN_PATH, name);
 		fd = open(buf, O_RDWR | O_TRUNC | O_CREAT, 0600);
 		if (fd < 0)
@@ -442,9 +498,9 @@ int bpf_object__open_skeleton(
 		}
 		link.fd = fd;
 		link.pin_path = buf;
-		link.prog = &g_obj.progs[i];
+		link.prog = &g_obj.progs[prog_base + i];
 		g_obj.links.push_back(std::move(link));
-		*s->progs[i].link = &g_obj.links[i];
+		*s->progs[i].link = &g_obj.links[link_base + i];
 	}
 	return 0;
 }


### PR DESCRIPTION
### 本次修改集中在 test 目录，修改内容如下

1.添加了 lsof 的 BUILTIN 单测。测试内容围绕工具实际功能补充了较完整的回归验证，覆盖了以下几类行为：

   - 帮助信息输出：验证 -h/--help 能正常打印 usage，并包含 path、dev、inode、help 等选项说明。
   - 非法参数处理：验证传入非法选项时会返回错误，并输出 usage，保证参数校验路径正确。
   - 互斥参数校验：验证 --path 与 --inode/--dev 不能同时使用，确保路径过滤和 inode 过滤两套模式不会被错误混用。
   - 组合参数校验：验证 --dev 与 --inode 必须成对出现，避免只传一半导致规则语义不完整。
   - 默认规则行为：验证未传过滤参数时，规则字段保持零值，工具会按默认模式汇总输出，不会写入脏规则。
   - path 过滤语义：验证指定 --path 后，只会汇总匹配该路径的文件和 VMA 记录，其他路径事件不会进入最终输出。
   - dev + inode 过滤语义：验证指定 --dev 和 --inode 后，只会输出设备号和 inode 同时匹配的记录，设备不匹配或 inode 不匹配的事件都会被过滤。
   - 文件与 VMA 聚合语义：验证同一进程下多个普通 fd 会被聚合展示，fd == -1 的 VMA 记录会按 vma(N) 形式汇总，确保输出符合工具设计。
   - 汇总输出格式：验证最终输出包含 COMM、UID、PID、FD 等表头，并能正确展示命中进程名、用户、进程号和 fd/VMA 聚合结果。
   - 多条件过滤结果一致性：验证过滤规则命中的记录会真正进入最终汇总，不命中的记录不会误出现在输出中，确保规则判断和最终日志一致。

2. 在test/Makefile 中补齐测试目标的链接依赖；
3. 在test/mock.cpp 中修正 skeleton 对象在全局容器中的分配、指针回填和销毁逻辑，避免因扩容和错索引导致的崩溃；