### PR TITLE
test: add trace-signal testing and builtin coverage for trace-signal …

### DIFF
--- a/test/Makefile
+++ b/test/Makefile
@@ -23,7 +23,8 @@ CXXFLAGS = -g -D__GTEST__ -DBUILTIN -MMD \
 		   -I$(PROJ_ROOT)/build/policy \
 		   -I$(PROJ_ROOT)/bpf/export
 
-LDFLAGS = -Wl,-rpath=$(PROJ_ROOT)/googletest/build/lib/
+LDFLAGS = -Wl,-rpath='$$ORIGIN/../../googletest/build/lib'
+LDLIBS = -lbpf -lpthread -lelf -lz
 
 GTEST_LIBS = $(PROJ_ROOT)/googletest/build/lib/libgtest_main.so	\
 			 $(PROJ_ROOT)/googletest/build/lib/libgtest.so
@@ -43,9 +44,10 @@ $(TARGET): $(OBJS) $(GTEST_LIBS) \
 	$(BUILD_DIR)/kmemleak.o \
 	$(BUILD_DIR)/irqsnoop.o \
 	$(BUILD_DIR)/mountsnoop.o \
+	$(BUILD_DIR)/trace-signal.o \
 	$(BUILD_DIR)/frtp.o \
 	$(BUILD_DIR)/elfverify.o
-	$(CXX) $^ $(LDFLAGS) -o $@
+	$(CXX) $^ $(LDFLAGS) $(LDLIBS) -o $@
 
 $(BUILD_DIR):
 	@mkdir -p $@

--- a/test/mock.cpp
+++ b/test/mock.cpp
@@ -68,6 +68,7 @@ struct bpf_map
 	size_t value_size;
 	size_t max_entries;
 	size_t sz;
+	size_t mmap_sz;
 	void *mem;
 	bpf_map_type type;
 	std::string name;
@@ -81,6 +82,15 @@ struct bpf_object
 	std::vector<bpf_link> links;
 };
 
+struct skeleton_offsets
+{
+	size_t map_base;
+	size_t prog_base;
+	size_t link_base;
+	int map_cnt;
+	int prog_cnt;
+};
+
 struct ring_buffer
 {
 	int map_fd;
@@ -90,6 +100,7 @@ struct ring_buffer
 };
 
 static bpf_object g_obj;
+static std::map<const bpf_object_skeleton *, skeleton_offsets> g_skeleton_offsets;
 
 std::string fd_path(int fd)
 {
@@ -293,22 +304,52 @@ void bpf_object__destroy_skeleton(struct bpf_object_skeleton *s)
 		return;
 	}
 
-	int fd;
-	char buf[PATH_MAX];
-
-	for (int i = 0; i < s->prog_cnt; i++)
+	auto offset_it = g_skeleton_offsets.find(s);
+	if (offset_it == g_skeleton_offsets.end())
 	{
-		close(g_obj.progs[i].fd);
-		close(g_obj.links[i].fd);
+		free(s->maps);
+		free(s->progs);
+		free(s);
+		return;
 	}
-	g_obj.progs.clear();
-	g_obj.links.clear();
+	const skeleton_offsets offsets = offset_it->second;
+
 	for (int i = 0; i < s->map_cnt; i++)
 	{
-		munmap(g_obj.maps[i].mem, g_obj.maps[i].sz);
-		close(g_obj.maps[i].fd);
+		if (s->maps[i].mmaped && *s->maps[i].mmaped)
+		{
+			free(*s->maps[i].mmaped);
+			*s->maps[i].mmaped = nullptr;
+		}
 	}
-	g_obj.maps.clear();
+
+	for (int i = 0; i < offsets.prog_cnt; i++)
+	{
+		close(g_obj.progs[offsets.prog_base + i].fd);
+		close(g_obj.links[offsets.link_base + i].fd);
+	}
+	g_obj.progs.erase(
+		g_obj.progs.begin() + offsets.prog_base,
+		g_obj.progs.begin() + offsets.prog_base + offsets.prog_cnt
+	);
+	g_obj.links.erase(
+		g_obj.links.begin() + offsets.link_base,
+		g_obj.links.begin() + offsets.link_base + offsets.prog_cnt
+	);
+	for (int i = 0; i < offsets.map_cnt; i++)
+	{
+		bpf_map &map = g_obj.maps[offsets.map_base + i];
+		if (map.mem)
+		{
+			munmap(map.mem, map.mmap_sz ? map.mmap_sz : map.sz);
+		}
+		close(map.fd);
+	}
+	g_obj.maps.erase(
+		g_obj.maps.begin() + offsets.map_base,
+		g_obj.maps.begin() + offsets.map_base + offsets.map_cnt
+	);
+	g_skeleton_offsets.erase(offset_it);
 	free(s->maps);
 	free(s->progs);
 	free(s);
@@ -319,7 +360,7 @@ int bpf_object__find_map_fd_by_name(
 	const char *name
 )
 {
-	for (int i = 0; i < obj->maps.size(); i++)
+	for (int i = (int)obj->maps.size() - 1; i >= 0; i--)
 	{
 		if (obj->maps[i].name == name)
 		{
@@ -345,15 +386,21 @@ int bpf_object__open_skeleton(
 
 	*s->obj = &g_obj;
 
+	const size_t map_base = g_obj.maps.size();
+	const size_t prog_base = g_obj.progs.size();
+	const size_t link_base = g_obj.links.size();
+	g_obj.maps.reserve(map_base + s->map_cnt);
+	g_obj.progs.reserve(prog_base + s->prog_cnt);
+	g_obj.links.reserve(link_base + s->prog_cnt);
+	g_skeleton_offsets[s] = {map_base, prog_base, link_base, s->map_cnt, s->prog_cnt};
+
 	int fd;
-	bpf_program prog;
-	bpf_map map;
-	bpf_link link;
 	const char *name;
 	char buf[PATH_MAX];
 
 	for (int i = 0; i < s->map_cnt; i++)
 	{
+		bpf_map map {};
 		name = s->maps[i].name;
 		snprintf(buf, PATH_MAX, "%s/map-%s", BPF_PIN_PATH, name);
 		fd = open(buf, O_RDWR | O_TRUNC | O_CREAT, 0600);
@@ -378,35 +425,43 @@ int bpf_object__open_skeleton(
 			map.sz = RB_MAP_SIZE;
 			map.type = BPF_MAP_TYPE_UNSPEC;
 		}
+		map.mmap_sz = 0;
 		int page_size = getpagesize();
 		if (strcmp(name, "dk_shared_mem") == 0 ||
 			map.type == BPF_MAP_TYPE_RINGBUF)
 		{
 			int ret = 0;
-			ret = ftruncate(fd, page_size * 2 + RB_MAP_SIZE);
+			map.mmap_sz = page_size * 2 + RB_MAP_SIZE;
+			ret = ftruncate(fd, map.mmap_sz);
 			assert(ret == 0);
 			map.type = BPF_MAP_TYPE_RINGBUF;
 			map.mem = mmap(
 				NULL,
-				page_size * 2 + RB_MAP_SIZE,
+				map.mmap_sz,
 				PROT_READ | PROT_WRITE,
 				MAP_SHARED,
 				fd,
 				0
 			);
 			assert(map.mem != MAP_FAILED);
-			memset(map.mem, 0, page_size * 2 + RB_MAP_SIZE);
+			memset(map.mem, 0, map.mmap_sz);
 		}
 		else
 		{
 			map.mem = nullptr;
 		}
 		g_obj.maps.push_back(std::move(map));
-		*s->maps[i].map = &g_obj.maps[i];
+		*s->maps[i].map = &g_obj.maps[map_base + i];
+		if (s->maps[i].mmaped)
+		{
+			*s->maps[i].mmaped = calloc(1, getpagesize());
+			assert(*s->maps[i].mmaped != nullptr);
+		}
 	}
 
 	for (int i = 0; i < s->prog_cnt; i++)
 	{
+		bpf_program prog {};
 		name = s->progs[i].name;
 		snprintf(buf, PATH_MAX, "%s/prog-%s", BPF_PIN_PATH, name);
 		fd = open(buf, O_RDWR | O_TRUNC | O_CREAT, 0600);
@@ -432,8 +487,9 @@ int bpf_object__open_skeleton(
 			}
 		}
 		g_obj.progs.push_back(std::move(prog));
-		*s->progs[i].prog = &g_obj.progs[i];
+		*s->progs[i].prog = &g_obj.progs[prog_base + i];
 
+		bpf_link link {};
 		snprintf(buf, PATH_MAX, "%s/link-%s", BPF_PIN_PATH, name);
 		fd = open(buf, O_RDWR | O_TRUNC | O_CREAT, 0600);
 		if (fd < 0)
@@ -442,9 +498,9 @@ int bpf_object__open_skeleton(
 		}
 		link.fd = fd;
 		link.pin_path = buf;
-		link.prog = &g_obj.progs[i];
+		link.prog = &g_obj.progs[prog_base + i];
 		g_obj.links.push_back(std::move(link));
-		*s->progs[i].link = &g_obj.links[i];
+		*s->progs[i].link = &g_obj.links[link_base + i];
 	}
 	return 0;
 }

--- a/test/trace-signal-test.cpp
+++ b/test/trace-signal-test.cpp
@@ -1,0 +1,539 @@
+// SPDX-FileCopyrightText: 2025 UnionTech Software Technology Co., Ltd
+//
+// SPDX-License-Identifier: LGPL-2.1
+
+// This file uses/derives from googletest
+// Copyright 2008, Google Inc.
+// Licensed under the BSD 3-Clause License
+// See NOTICE for full license text
+
+#include "gtest/gtest.h"
+#include "jhash.h"
+
+#include <atomic>
+#include <bpf/bpf.h>
+#include <cstdio>
+#include <filesystem>
+#include <fstream>
+#include <string>
+#include <thread>
+#include <vector>
+
+#define COMM_MAX_LEN 16
+#define TEST_EVENT_MAX 32
+
+struct Rule
+{
+	pid_t sender_pid;
+	uint32_t sender_phash;
+	pid_t recv_pid;
+	uint32_t recv_phash;
+	int sig;
+	int res;
+};
+
+struct Test_Event
+{
+	pid_t sender_pid;
+	char sender_comm[COMM_MAX_LEN];
+	pid_t recv_pid;
+	char recv_comm[COMM_MAX_LEN];
+	int sig;
+	int res;
+	uint32_t sender_phash;
+	uint32_t recv_phash;
+};
+struct BpfData
+{
+	pid_t sender_pid;
+	char sender_comm[COMM_MAX_LEN];
+	pid_t recv_pid;
+	char recv_comm[COMM_MAX_LEN];
+	int sig;
+	int res;
+};
+
+static const std::string TEST_ROOT = "/tmp/trace_signal_test_dir";
+static const std::string TEST_LOG_FILE = TEST_ROOT + "/log.txt";
+static Test_Event g_test_events[TEST_EVENT_MAX] = {};
+static size_t g_test_event_count = 0;
+static std::atomic<int> g_condition = 0;
+static std::atomic<bool> *g_exit_flag = nullptr;
+void trace_signal_init(
+	FILE *output,
+	std::atomic<int> *conditionp,
+	std::atomic<bool> **exit_flagp,
+	int *filter_fd,
+	int *log_fd
+);
+extern int trace_signal_main(int argc, char *argvp[]);
+extern void trace_signal_deinit();
+extern long bpf_for_each_map_elem(int fd, void *callback_fn, void *callback_ctx, unsigned long long flags);
+extern int ring_buffer__push(int fd, void *data, size_t sz);
+
+static long match_call(struct bpf_map *map, const void *key, void *value, void *ctx)
+{
+    struct Test_Event *test_event = (struct Test_Event *)ctx;
+    struct Rule *rule = (struct Rule *)value;
+    if(rule->sender_pid > 0 && rule->sender_pid != (pid_t)-1 && test_event->sender_pid != rule->sender_pid){
+        return 0;
+    }
+	if(rule->recv_pid > 0 && rule->recv_pid != (pid_t)-1 && test_event->recv_pid != rule->recv_pid){
+        return 0;
+    }
+	if(rule->sig > 0 && rule->sig != (int)-1 && test_event->sig != rule->sig){
+        return 0;
+    }
+	if(rule->res > 0 && rule->res != (int)-1 && test_event->res != rule->res){
+		return 0;
+    }
+	if(rule->sender_phash != 0 && test_event->sender_phash != rule->sender_phash){
+		return 0;
+	}
+	if(rule->recv_phash != 0 && test_event->recv_phash != rule->recv_phash){
+		return 0;
+	}
+	return 1;
+}
+static bool rules_filter(int filter_fd, struct Test_Event &event)
+{
+	return bpf_for_each_map_elem(filter_fd, (void *)match_call, &event, 0) == 1;
+}
+static void event_worker(
+    Test_Event *test_events,
+    size_t test_event_count,
+    std::atomic<int> &condition ,
+    std::atomic<bool> *exit_flag,
+    int *filter_fdp, 
+    int *log_fdp
+)
+{
+    while(condition <= 0)
+    {
+        std::this_thread::sleep_for(std::chrono::microseconds(5));
+    }
+    if(condition != 1)
+    {
+        *exit_flag = true;
+        return;
+    }
+    auto filter_fd = *filter_fdp;
+    auto log_fd = *log_fdp;
+    for(size_t i = 0; i < test_event_count; ++i)
+    {
+        auto &e = test_events[i];
+        if(rules_filter(filter_fd, e)){
+			struct BpfData log_data = {}; 
+			log_data.sender_pid = e.sender_pid;
+			log_data.recv_pid = e.recv_pid;
+			log_data.sig = e.sig;
+			log_data.res = e.res;
+			strcpy(log_data.sender_comm, e.sender_comm);
+			strcpy(log_data.recv_comm, e.recv_comm);
+			int ret = ring_buffer__push(log_fd, &log_data, sizeof(log_data));
+        }    
+    }
+    condition = 2;
+	*exit_flag = true;
+}
+class TraceSignalTest : public ::testing::Test
+{
+    protected:
+        void SetUp() override
+        {
+            createTestFiles();
+            memset(g_test_events, 0, sizeof(g_test_events));
+            g_test_event_count = 0;
+            g_condition = 0;
+            g_exit_flag = nullptr;
+        }
+        void TearDown() override
+        {
+            cleanTestFiles();
+        }
+        void createTestFiles()
+        {
+            system(("mkdir -p " + TEST_ROOT).c_str());
+        }
+        void cleanTestFiles()
+        {
+            system(("rm -rf " + TEST_ROOT).c_str());
+        }
+        bool existStr(const std::string &str)
+        {
+            std::ifstream file(TEST_LOG_FILE, std::ios::binary | std::ios::ate);
+            if(!file.is_open())
+            {
+                return false;
+            }
+            std::streamsize size = file.tellg();
+            file.seekg(0, std::ios::beg);
+            std::string content(size, '\0');
+            if(!file.read(&content[0],size)){
+                return false;
+            }
+            return content.find(str) != std::string::npos;
+        }
+          std::string readLog()
+        {
+            std::ifstream file(TEST_LOG_FILE, std::ios::binary | std::ios::ate);
+            if (!file.is_open())
+            {
+                return "";
+            }
+
+            std::streamsize size = file.tellg();
+            file.seekg(0, std::ios::beg);
+
+            std::string content(size, '\0');
+            if (!file.read(&content[0], size))
+            {
+                return "";
+            }
+            return content;
+        }
+        int countStr(const std::string &str)
+        {
+            std::ifstream file(TEST_LOG_FILE, std::ios::binary | std::ios::ate);
+            if(!file.is_open())
+            {
+                return false;
+            }
+            std::streamsize size = file.tellg();
+            file.seekg(0, std::ios::beg);
+            std::string content(size, '\0');
+            if(!file.read(&content[0],size)){
+                return false;
+            }
+            int count = 0;
+            size_t pos = 0;
+            while((pos = content.find(str, pos)) != std::string::npos) {
+                ++count;
+                pos += str.length();
+            }
+            return count;
+        }
+        void addTestEvent(uint32_t sender_pid, 
+						  uint32_t recv_pid, 
+						  const char *sender_comm, 
+						  const char *recv_comm, 
+						  const char *sender_path, 
+						  const char *recv_path, 
+						  int32_t sig, int32_t res){
+            ASSERT_LT(g_test_event_count, (size_t)TEST_EVENT_MAX);
+            auto &e = g_test_events[g_test_event_count++];
+            memset(&e, 0, sizeof(e));
+            e.sender_pid = sender_pid;
+            e.recv_pid = recv_pid;
+			e.sig = sig;
+			e.res = res;
+            if (sender_comm!= nullptr) {
+                strncpy(e.sender_comm , sender_comm, sizeof(e.sender_comm ) - 1);
+                e.sender_comm[sizeof(e.sender_comm) - 1] = '\0';
+            } else {
+                e.sender_comm[0] = '\0'; // 如果为空，设为空字符串
+            }
+            if (recv_comm!= nullptr) {
+                strncpy(e.recv_comm , recv_comm, sizeof(e.recv_comm ) - 1);
+                e.recv_comm[sizeof(e.recv_comm) - 1] = '\0';
+            } else {
+                e.recv_comm[0] = '\0'; // 如果为空，设为空字符串
+            }
+            uint32_t sender_phash = 0;
+            if(sender_path != nullptr){
+                char *buf = (char *)calloc(4096, sizeof(char)); // 从堆区申请内存
+                if (!buf)
+                {
+                    perror("calloc");
+                    exit(EXIT_FAILURE);
+                }
+                strncpy(buf, sender_path, 4096);
+                buf[4095] = '\0';
+                sender_phash =  jhash(buf, 4096, 0);
+                free(buf);
+            }
+			uint32_t recv_phash = 0;
+            if(recv_path != nullptr){
+                char *buf = (char *)calloc(4096, sizeof(char)); // 从堆区申请内存
+                if (!buf)
+                {
+                    perror("calloc");
+                    exit(EXIT_FAILURE);
+                }
+                strncpy(buf, recv_path, 4096);
+                buf[4095] = '\0';
+                recv_phash =  jhash(buf, 4096, 0);
+                free(buf);
+            }
+			e.sender_phash = sender_phash;
+			e.recv_phash = recv_phash;
+        }
+        int runTraceSignal(const std::vector<std::string> &_args){
+            g_condition = 0;
+            g_exit_flag = nullptr;
+            std::vector<std::string> t;
+            t.push_back("trace-signal");
+            t.insert(t.end(),_args.begin(), _args.end());
+            std::vector<char *> argv;
+            argv.reserve(t.size());
+            for(const auto &arg : t){
+                argv.push_back(const_cast<char *>(arg.c_str()));
+            }
+            argv.push_back(nullptr);
+            FILE *log_file = fopen(TEST_LOG_FILE.c_str(),"w");
+            int filter_fd, log_fd;
+            trace_signal_init(log_file, &g_condition ,&g_exit_flag, &filter_fd, &log_fd);
+            std::thread *event_theard = new std::thread(
+                event_worker,
+                g_test_events,
+                g_test_event_count,
+                std::ref(g_condition),
+                g_exit_flag,
+                &filter_fd,
+                &log_fd
+            );
+            int ret = trace_signal_main((int)t.size(), argv.data());
+            event_theard->join();
+            delete event_theard;
+            trace_signal_deinit();
+            fclose(log_file);
+            return ret;
+        }
+};
+TEST_F(TraceSignalTest, SimpleTest1)
+{
+    runTraceSignal({"-h"});
+    EXPECT_TRUE(existStr("Usage:"));
+}
+//测试能否正常输出数据
+TEST_F(TraceSignalTest, SimpleTest2)
+{
+	addTestEvent(3027354, 2649772, "sender1", "receiver1", "/tmp/trace_signal_test_dir/sender1", "/tmp/trace_signal_test_dir/receiver1", 2, 0);
+	addTestEvent(3070643, 2649682, "sender2", "receiver2", "/tmp/trace_signal_test_dir/sender2", "/tmp/trace_signal_test_dir/receiver2", 0, 0);
+	addTestEvent(945692, 2649772, "sender3", "receiver3", "/tmp/trace_signal_test_dir/sender3", "/tmp/trace_signal_test_dir/receiver3", 4, 1);
+    runTraceSignal({""});
+    EXPECT_TRUE(existStr("=============== filter ================="));
+	EXPECT_TRUE(existStr("sender_pid = 0"));
+    EXPECT_TRUE(existStr("sender_phash = 0"));
+    EXPECT_TRUE(existStr("recv_pid = 0"));
+    EXPECT_TRUE(existStr("recv_phash = 0"));
+    EXPECT_TRUE(existStr("signal = 0"));
+    EXPECT_TRUE(existStr("return = 0"));
+	EXPECT_TRUE(existStr("SENDER          S-COMM      RCVER          R-COMM       SIGNAL   RESULT"));
+	EXPECT_TRUE(existStr("3027354         sender1    2649772       receiver1    Interrupt        0"));
+    EXPECT_TRUE(existStr("3070643         sender2    2649682       receiver2            0        0"));
+	EXPECT_TRUE(existStr("945692         sender3    2649772       receiver3 Illegal instruction        1"));
+}
+//测试能否正常根据 -P senderID过滤
+TEST_F(TraceSignalTest, SenderPidFilterApplied)
+{
+	addTestEvent(3027354, 2649772, "sender1", "receiver1", "/tmp/trace_signal_test_dir/sender1", "/tmp/trace_signal_test_dir/receiver1", 2, 0);
+	addTestEvent(3070643, 2649682, "sender2", "receiver2", "/tmp/trace_signal_test_dir/sender2", "/tmp/trace_signal_test_dir/receiver2", 0, 0);
+	addTestEvent(945692, 2649772, "sender3", "receiver3", "/tmp/trace_signal_test_dir/sender3", "/tmp/trace_signal_test_dir/receiver3", 4, 1);
+    runTraceSignal({"-P","945692"});
+    EXPECT_TRUE(existStr("=============== filter ================="));
+	EXPECT_TRUE(existStr("sender_pid = 945692"));
+    EXPECT_TRUE(existStr("sender_phash = 0"));
+    EXPECT_TRUE(existStr("recv_pid = 0"));
+    EXPECT_TRUE(existStr("recv_phash = 0"));
+    EXPECT_TRUE(existStr("signal = 0"));
+    EXPECT_TRUE(existStr("return = 0"));
+	EXPECT_TRUE(existStr("SENDER          S-COMM      RCVER          R-COMM       SIGNAL   RESULT"));
+	EXPECT_TRUE(!existStr("3027354         sender1    2649772       receiver1    Interrupt        0"));
+    EXPECT_TRUE(!existStr("3070643         sender2    2649682       receiver2            0        0"));
+	EXPECT_TRUE(existStr("945692         sender3    2649772       receiver3 Illegal instruction        1"));
+}
+//测试能否正常根据 -P receiverID过滤
+TEST_F(TraceSignalTest, ReceiverPidFilterApplied)
+{
+	addTestEvent(3027354, 2649772, "sender1", "receiver1", "/tmp/trace_signal_test_dir/sender1", "/tmp/trace_signal_test_dir/receiver1", 2, 0);
+	addTestEvent(3070643, 2649682, "sender2", "receiver2", "/tmp/trace_signal_test_dir/sender2", "/tmp/trace_signal_test_dir/receiver2", 0, 0);
+	addTestEvent(945692, 2649772, "sender3", "receiver3", "/tmp/trace_signal_test_dir/sender3", "/tmp/trace_signal_test_dir/receiver3", 4, 1);
+    runTraceSignal({"-p","2649682"});
+    EXPECT_TRUE(existStr("=============== filter ================="));
+	EXPECT_TRUE(existStr("sender_pid = 0"));
+    EXPECT_TRUE(existStr("sender_phash = 0"));
+    EXPECT_TRUE(existStr("recv_pid = 2649682"));
+    EXPECT_TRUE(existStr("recv_phash = 0"));
+    EXPECT_TRUE(existStr("signal = 0"));
+    EXPECT_TRUE(existStr("return = 0"));
+	EXPECT_TRUE(existStr("SENDER          S-COMM      RCVER          R-COMM       SIGNAL   RESULT"));
+	EXPECT_TRUE(!existStr("3027354         sender1    2649772       receiver1    Interrupt        0"));
+    EXPECT_TRUE(existStr("3070643         sender2    2649682       receiver2            0        0"));
+	EXPECT_TRUE(!existStr("945692         sender3    2649772       receiver3 Illegal instruction        1"));
+}
+//测试能否正常根据 -s senderProg过滤
+TEST_F(TraceSignalTest, SenderProgramFilterApplied)
+{
+	addTestEvent(3027354, 2649772, "sender1", "receiver1", "/tmp/trace_signal_test_dir/sender1", "/tmp/trace_signal_test_dir/receiver1", 2, 0);
+	addTestEvent(3070643, 2649682, "sender2", "receiver2", "/tmp/trace_signal_test_dir/sender2", "/tmp/trace_signal_test_dir/receiver2", 0, 0);
+	addTestEvent(945692, 2649772, "sender3", "receiver3", "/tmp/trace_signal_test_dir/sender3", "/tmp/trace_signal_test_dir/receiver3", 4, 1);
+    runTraceSignal({"-s","/tmp/trace_signal_test_dir/sender3"});
+    char *buf = (char *)calloc(4096, 1);
+    memset(buf, 0, 4096);
+	strncpy(buf, "/tmp/trace_signal_test_dir/sender3", 4096);
+	buf[4095] = 0;
+	uint32_t sender_phash = jhash2((u32 *)buf, 4096 / 4, 0);
+    free(buf);
+    EXPECT_TRUE(existStr("=============== filter ================="));
+	EXPECT_TRUE(existStr("sender_pid = 0"));
+    EXPECT_TRUE(existStr("sender_phash = " + std::to_string(sender_phash)));
+    EXPECT_TRUE(existStr("recv_pid = 0"));
+    EXPECT_TRUE(existStr("recv_phash = 0"));
+    EXPECT_TRUE(existStr("signal = 0"));
+    EXPECT_TRUE(existStr("return = 0"));
+	EXPECT_TRUE(existStr("SENDER          S-COMM      RCVER          R-COMM       SIGNAL   RESULT"));
+	EXPECT_TRUE(!existStr("3027354         sender1    2649772       receiver1    Interrupt        0"));
+    EXPECT_TRUE(!existStr("3070643         sender2    2649682       receiver2            0        0"));
+	EXPECT_TRUE(existStr("945692         sender3    2649772       receiver3 Illegal instruction        1"));
+}
+//测试能否正常根据 -r receiverProg过滤
+TEST_F(TraceSignalTest, ReceiverProgramFilterApplied)
+{
+	addTestEvent(3027354, 2649772, "sender1", "receiver1", "/tmp/trace_signal_test_dir/sender1", "/tmp/trace_signal_test_dir/receiver1", 2, 0);
+	addTestEvent(3070643, 2649682, "sender2", "receiver2", "/tmp/trace_signal_test_dir/sender2", "/tmp/trace_signal_test_dir/receiver2", 0, 0);
+	addTestEvent(945692, 2649772, "sender3", "receiver3", "/tmp/trace_signal_test_dir/sender3", "/tmp/trace_signal_test_dir/receiver3", 4, 1);
+    runTraceSignal({"-r","/tmp/trace_signal_test_dir/receiver2"});
+    char *buf = (char *)calloc(4096, 1);
+    memset(buf, 0, 4096);
+	strncpy(buf, "/tmp/trace_signal_test_dir/receiver2", 4096);
+	buf[4095] = 0;
+	uint32_t recv_phash = jhash2((u32 *)buf, 4096 / 4, 0);
+    free(buf);
+    EXPECT_TRUE(existStr("=============== filter ================="));
+	EXPECT_TRUE(existStr("sender_pid = 0"));
+    EXPECT_TRUE(existStr("sender_phash = 0" ));
+    EXPECT_TRUE(existStr("recv_pid = 0"));
+    EXPECT_TRUE(existStr("recv_phash = " + std::to_string(recv_phash)));
+    EXPECT_TRUE(existStr("signal = 0"));
+    EXPECT_TRUE(existStr("return = 0"));
+	EXPECT_TRUE(existStr("SENDER          S-COMM      RCVER          R-COMM       SIGNAL   RESULT"));
+	EXPECT_TRUE(!existStr("3027354         sender1    2649772       receiver1    Interrupt        0"));
+    EXPECT_TRUE(existStr("3070643         sender2    2649682       receiver2            0        0"));
+	EXPECT_TRUE(!existStr("945692         sender3    2649772       receiver3 Illegal instruction        1"));
+}
+//测试能否正常根据 -S signal过滤
+TEST_F(TraceSignalTest, SignalFilterApplied)
+{
+	addTestEvent(3027354, 2649772, "sender1", "receiver1", "/tmp/trace_signal_test_dir/sender1", "/tmp/trace_signal_test_dir/receiver1", 2, 0);
+	addTestEvent(3070643, 2649682, "sender2", "receiver2", "/tmp/trace_signal_test_dir/sender2", "/tmp/trace_signal_test_dir/receiver2", 0, 0);
+	addTestEvent(945692, 2649772, "sender3", "receiver3", "/tmp/trace_signal_test_dir/sender3", "/tmp/trace_signal_test_dir/receiver3", 4, 1);
+    runTraceSignal({"-S","4"});
+    EXPECT_TRUE(existStr("=============== filter ================="));
+	EXPECT_TRUE(existStr("sender_pid = 0"));
+    EXPECT_TRUE(existStr("sender_phash = 0"));
+    EXPECT_TRUE(existStr("recv_pid = 0"));
+    EXPECT_TRUE(existStr("recv_phash = 0"));
+    EXPECT_TRUE(existStr("signal = 4"));
+    EXPECT_TRUE(existStr("return = 0"));
+	EXPECT_TRUE(existStr("SENDER          S-COMM      RCVER          R-COMM       SIGNAL   RESULT"));
+	EXPECT_TRUE(!existStr("3027354         sender1    2649772       receiver1    Interrupt        0"));
+    EXPECT_TRUE(!existStr("3070643         sender2    2649682       receiver2            0        0"));
+	EXPECT_TRUE(existStr("945692         sender3    2649772       receiver3 Illegal instruction        1"));
+}
+//测试能否正常根据 -S result过滤
+TEST_F(TraceSignalTest, ResultFilterApplied)
+{
+	addTestEvent(3027354, 2649772, "sender1", "receiver1", "/tmp/trace_signal_test_dir/sender1", "/tmp/trace_signal_test_dir/receiver1", 2, 2);
+	addTestEvent(3070643, 2649682, "sender2", "receiver2", "/tmp/trace_signal_test_dir/sender2", "/tmp/trace_signal_test_dir/receiver2", 0, 0);
+	addTestEvent(945692, 2649772, "sender3", "receiver3", "/tmp/trace_signal_test_dir/sender3", "/tmp/trace_signal_test_dir/receiver3", 4, 1);
+    runTraceSignal({"-R","2"});
+    EXPECT_TRUE(existStr("=============== filter ================="));
+	EXPECT_TRUE(existStr("sender_pid = 0"));
+    EXPECT_TRUE(existStr("sender_phash = 0"));
+    EXPECT_TRUE(existStr("recv_pid = 0"));
+    EXPECT_TRUE(existStr("recv_phash = 0"));
+    EXPECT_TRUE(existStr("signal = 0"));
+    EXPECT_TRUE(existStr("return = 2"));
+	EXPECT_TRUE(existStr("SENDER          S-COMM      RCVER          R-COMM       SIGNAL   RESULT"));
+	EXPECT_TRUE(existStr("3027354         sender1    2649772       receiver1    Interrupt        2"));
+    EXPECT_TRUE(!existStr("3070643         sender2    2649682       receiver2            0        0"));
+	EXPECT_TRUE(!existStr("945692         sender3    2649772       receiver3 Illegal instruction        1"));
+}
+//测试组合过滤条件能否正常工作
+TEST_F(TraceSignalTest, CombinedFiltersApplied)
+{
+	addTestEvent(3027354, 2649772, "sender1", "receiver1", "/tmp/trace_signal_test_dir/sender1", "/tmp/trace_signal_test_dir/receiver1", 2, 2);
+	addTestEvent(3070643, 2649682, "sender2", "receiver2", "/tmp/trace_signal_test_dir/sender2", "/tmp/trace_signal_test_dir/receiver2", 0, 0);
+	addTestEvent(945692, 2649772, "sender3", "receiver3", "/tmp/trace_signal_test_dir/sender3", "/tmp/trace_signal_test_dir/receiver3", 4, 1);
+    runTraceSignal({"-P","3027354","-p","2649772","-s","/tmp/trace_signal_test_dir/sender1","-r","/tmp/trace_signal_test_dir/receiver1","-S","2","-R","2"});
+    char *buf = (char *)calloc(4096, 1);
+    char *buf1 = (char *)calloc(4096, 1);
+    memset(buf, 0, 4096);
+    memset(buf1, 0, 4096);
+	strncpy(buf, "/tmp/trace_signal_test_dir/sender1", 4096);
+    strncpy(buf1, "/tmp/trace_signal_test_dir/receiver1", 4096);
+	buf[4095] = 0;
+    buf1[4035] = 0;
+	uint32_t sender_phash = jhash2((u32 *)buf, 4096 / 4, 0);
+    uint32_t recv_phash = jhash2((u32 *)buf1, 4096 / 4, 0);
+    free(buf);
+    free(buf1);
+    EXPECT_TRUE(existStr("=============== filter ================="));
+	EXPECT_TRUE(existStr("sender_pid = 3027354"));
+    EXPECT_TRUE(existStr("sender_phash = " + std::to_string(sender_phash)));
+    EXPECT_TRUE(existStr("recv_pid = 2649772"));
+    EXPECT_TRUE(existStr("recv_phash = " + std::to_string(recv_phash)));
+    EXPECT_TRUE(existStr("signal = 2"));
+    EXPECT_TRUE(existStr("return = 2"));
+	EXPECT_TRUE(existStr("SENDER          S-COMM      RCVER          R-COMM       SIGNAL   RESULT"));
+	EXPECT_TRUE(existStr("3027354         sender1    2649772       receiver1    Interrupt        2"));
+    EXPECT_TRUE(!existStr("3070643         sender2    2649682       receiver2            0        0"));
+	EXPECT_TRUE(!existStr("945692         sender3    2649772       receiver3 Illegal instruction        1"));
+}
+//测试能否正常根据 -P senderID过滤非法输入
+TEST_F(TraceSignalTest, InvalidSenderPidRejected)
+{
+    addTestEvent(3027354, 2649772, "sender1", "receiver1", "/tmp/trace_signal_test_dir/sender1", "/tmp/trace_signal_test_dir/receiver1", 2, 2);
+	addTestEvent(3070643, 2649682, "sender2", "receiver2", "/tmp/trace_signal_test_dir/sender2", "/tmp/trace_signal_test_dir/receiver2", 0, 0);
+	addTestEvent(945692, 2649772, "sender3", "receiver3", "/tmp/trace_signal_test_dir/sender3", "/tmp/trace_signal_test_dir/receiver3", 4, 1);
+    runTraceSignal({"-P","-1"});
+    EXPECT_TRUE(existStr("wrong sender pid value: -1, must be a positive integer"));
+    runTraceSignal({"-P","12abc"});
+    EXPECT_TRUE(existStr("wrong sender pid value: 12abc, must be a positive integer"));
+    runTraceSignal({"-P","1000000000000000"});
+    EXPECT_TRUE(existStr("wrong sender pid value: 1000000000000000, must be a positive integer"));
+    EXPECT_TRUE(!existStr("=============== filter ================="));
+}
+//测试能否正常根据 -p receiverID过滤非法输入
+TEST_F(TraceSignalTest, InvalidReceiverPidRejected)
+{
+    addTestEvent(3027354, 2649772, "sender1", "receiver1", "/tmp/trace_signal_test_dir/sender1", "/tmp/trace_signal_test_dir/receiver1", 2, 2);
+	addTestEvent(3070643, 2649682, "sender2", "receiver2", "/tmp/trace_signal_test_dir/sender2", "/tmp/trace_signal_test_dir/receiver2", 0, 0);
+	addTestEvent(945692, 2649772, "sender3", "receiver3", "/tmp/trace_signal_test_dir/sender3", "/tmp/trace_signal_test_dir/receiver3", 4, 1);
+    runTraceSignal({"-p","-1"});
+    EXPECT_TRUE(existStr("wrong receiver pid value: -1, must be a positive integer"));
+    runTraceSignal({"-p","12abc"});
+    EXPECT_TRUE(existStr("wrong receiver pid value: 12abc, must be a positive integer"));
+    runTraceSignal({"-p","1000000000000000"});
+    EXPECT_TRUE(existStr("wrong receiver pid value: 1000000000000000, must be a positive integer"));
+    EXPECT_TRUE(!existStr("=============== filter ================="));
+}
+//测试能否正常根据 -S signal过滤非法输入
+TEST_F(TraceSignalTest, InvalidSignalRejected)
+{
+    addTestEvent(3027354, 2649772, "sender1", "receiver1", "/tmp/trace_signal_test_dir/sender1", "/tmp/trace_signal_test_dir/receiver1", 2, 2);
+	addTestEvent(3070643, 2649682, "sender2", "receiver2", "/tmp/trace_signal_test_dir/sender2", "/tmp/trace_signal_test_dir/receiver2", 0, 0);
+	addTestEvent(945692, 2649772, "sender3", "receiver3", "/tmp/trace_signal_test_dir/sender3", "/tmp/trace_signal_test_dir/receiver3", 4, 1);
+    runTraceSignal({"-S","-1"});
+    EXPECT_TRUE(existStr("wrong signal value: -1, must be a positive integer"));
+    runTraceSignal({"-S","12abc"});
+    EXPECT_TRUE(existStr("wrong signal value: 12abc, must be a positive integer"));
+    runTraceSignal({"-S","1000000000000000"});
+    EXPECT_TRUE(existStr("wrong signal value: 1000000000000000, must be a positive integer"));
+    EXPECT_TRUE(!existStr("=============== filter ================="));
+}
+//测试能否正常根据 -R result过滤非法输入
+TEST_F(TraceSignalTest, InvalidResultRejected)
+{
+    addTestEvent(3027354, 2649772, "sender1", "receiver1", "/tmp/trace_signal_test_dir/sender1", "/tmp/trace_signal_test_dir/receiver1", 2, 2);
+	addTestEvent(3070643, 2649682, "sender2", "receiver2", "/tmp/trace_signal_test_dir/sender2", "/tmp/trace_signal_test_dir/receiver2", 0, 0);
+	addTestEvent(945692, 2649772, "sender3", "receiver3", "/tmp/trace_signal_test_dir/sender3", "/tmp/trace_signal_test_dir/receiver3", 4, 1);
+    runTraceSignal({"-R","-1"});
+    EXPECT_TRUE(existStr("wrong result value: -1, must be an integer"));
+    runTraceSignal({"-R","12abc"});
+    EXPECT_TRUE(existStr("wrong result value: 12abc, must be an integer"));
+    runTraceSignal({"-R","1000000000000000"});
+    EXPECT_TRUE(existStr("wrong result value: 1000000000000000, must be an integer"));
+    EXPECT_TRUE(!existStr("=============== filter ================="));
+}


### PR DESCRIPTION
### 本次修改集中在 test 目录，修改内容如下

1.添加了 trace-siganl 的 BUILTIN 单测。测试内容围绕工具实际功能补充了较完整的回归验证，覆盖了以下几类行为：

- 测试能否正常输出数据
- 测试能否正常根据 -P senderID过滤
- 测试能否正常根据 -P receiverID过滤
- 测试能否正常根据 -s senderProg过滤
- 测试能否正常根据 -r receiverProg过滤
- 测试能否正常根据 -S signal过滤
- 测试能否正常根据 -S result过滤
- 测试组合过滤条件能否正常工作
- 测试能否正常根据 -P senderID过滤非法输入
- 测试能否正常根据 -p receiverID过滤非法输入
- 测试能否正常根据 -S signal过滤非法输入
- 测试能否正常根据 -R result过滤非法输入

2.在test/Makefile 中补齐测试目标的链接依赖；

3.在test/mock.cpp 中修正 skeleton 对象在全局容器中的分配、指针回填和销毁逻辑，避免因扩容和错索引导致的崩溃；

