### PR TITLE
fix(syscall-stat): stop skipping syscall key 0 during stats traversal and no top mode

### DIFF
--- a/observe/syscall-stat.cpp
+++ b/observe/syscall-stat.cpp
@@ -184,6 +184,9 @@ void parse_args(int argc, char **argv)
 				exit(-1);
 			}
 			break;
+		case 't':
+			top = true;
+			break;
 		case 'h': // Help
 			Usage(argv[0]);
 			free(buf);
@@ -288,25 +291,34 @@ void *timer_task(void *)
 		std::vector<std::pair<u32, info>> stats; // Vector to store syscall
 												 // stats
 
-		while (0 == bpf_map_get_next_key(stats_fd, &key, &nxt_key))
+		int ret  = bpf_map_get_next_key(stats_fd, NULL, &nxt_key);
+		while (0 == ret)
 		{
 			info sys_stat;
-			bpf_map_lookup_elem(stats_fd, &nxt_key, &sys_stat);
+			int lret = bpf_map_lookup_elem(stats_fd, &nxt_key, &sys_stat);
+			if (lret < 0) {
+				key = nxt_key;
+				ret = bpf_map_get_next_key(stats_fd, &key, &nxt_key);
+				continue;
+			}
 			if (nxt_key >= sizeof(sys_tbl) / sizeof(sys_tbl[0]))
 			{
-				key = nxt_key;
-				continue;
+					key = nxt_key;
+					ret = bpf_map_get_next_key(stats_fd, &key, &nxt_key);
+					continue;
 			}
 			if (sys_stat.cnt == 0)
 			{
-				key = nxt_key;
-				continue;
+					key = nxt_key;
+					ret = bpf_map_get_next_key(stats_fd, &key, &nxt_key);
+					continue;
 			}
 			stats.push_back({nxt_key, sys_stat});
 			total += sys_stat.cnt;
 			memset(&sys_stat, 0, sizeof(sys_stat));
 			bpf_map_update_elem(stats_fd, &nxt_key, &sys_stat, BPF_ANY);
 			key = nxt_key;
+			ret = bpf_map_get_next_key(stats_fd, &key, &nxt_key);
 		}
 
 		// Sort stats by sys_stat in descending order


### PR DESCRIPTION
 **修复了两个测试过程中发现的 Bug**

   - **Bug 1: 修复系统调用号 0 (read) 统计丢失问题**
     - **原因**：原逻辑中 `key` 初始化为 0，且使用 `bpf_map_get_next_key` 查找下一个 key。第一个 key 就是 0，`get_next_key` 会跳过它直接找下一个，后续使用nxt_key作为真正第一个开始查找的key，导致 `系统调用号为0的read`  syscall 永远不被统计。
     - **修复**：调整遍历逻辑，确保从第一个 key 开始完整遍历。
     - **代码如下**：
       ```cpp
       u32 key = 0, nxt_key;
       u32 total = 0;
       std::vector<std::pair<u32, info>> stats; 

       // 先尝试获取第一个 key
       if (bpf_map_get_next_key(stats_fd, nullptr, &key) != 0) {
           return; // Map is empty
       }

       do {
           info sys_stat;
           if (bpf_map_lookup_elem(stats_fd, &key, &sys_stat) != 0) {
               key = nxt_key;
               continue;
           }

           if (key >= sizeof(sys_tbl) / sizeof(sys_tbl[0])) {
               break; 
           }

           if (sys_stat.cnt > 0) {
               stats.push_back({key, sys_stat});
               total += sys_stat.cnt;
               
               // Clear the stat after reading
               memset(&sys_stat, 0, sizeof(sys_stat));
               bpf_map_update_elem(stats_fd, &key, &sys_stat, BPF_ANY);
           }
           
           // Get next key for the next iteration
           if (bpf_map_get_next_key(stats_fd, &key, &nxt_key) != 0) {
               break; // No more keys
           }
           key = nxt_key;
       } while (true);
       ```

   - **Bug 2: 修复 `--top` / `-t` 动态刷新功能无效问题**
     - **原因**：虽然底层动态刷新逻辑已实现，但在 `parse_args` 参数解析函数中遗漏了对 `-t` 和 `--top` 选项的处理。
     - **修复**：在 `parse_args` 中添加了对应的 case 分支，使终端能正确识别并开启动态刷新模式。