### PR TITLE
test: add lsof testing and builtin coverage for lsof tool

### DIFF
--- a/test/Makefile
+++ b/test/Makefile
@@ -23,7 +23,8 @@ CXXFLAGS = -g -D__GTEST__ -DBUILTIN -MMD \
 		   -I$(PROJ_ROOT)/build/policy \
 		   -I$(PROJ_ROOT)/bpf/export
 
-LDFLAGS = -Wl,-rpath=$(PROJ_ROOT)/googletest/build/lib/
+LDFLAGS = -Wl,-rpath='$$ORIGIN/../../googletest/build/lib'
+LDLIBS = -lbpf -lpthread -lelf -lz
 
 GTEST_LIBS = $(PROJ_ROOT)/googletest/build/lib/libgtest_main.so	\
 			 $(PROJ_ROOT)/googletest/build/lib/libgtest.so
@@ -39,13 +40,14 @@ all: $(TARGET)
 
 $(TARGET): $(OBJS) $(GTEST_LIBS) \
 	$(BUILD_DIR)/trace-file.o \
+	$(BUILD_DIR)/lsof.o \
 	$(BUILD_DIR)/lsock.o \
 	$(BUILD_DIR)/kmemleak.o \
 	$(BUILD_DIR)/irqsnoop.o \
 	$(BUILD_DIR)/mountsnoop.o \
 	$(BUILD_DIR)/frtp.o \
 	$(BUILD_DIR)/elfverify.o
-	$(CXX) $^ $(LDFLAGS) -o $@
+	$(CXX) $^ $(LDFLAGS) $(LDLIBS) -o $@
 
 $(BUILD_DIR):
 	@mkdir -p $@

--- a/test/lsof-test.cpp
+++ b/test/lsof-test.cpp
@@ -1,0 +1,387 @@
+#include "gtest/gtest.h"
+#include <iostream>
+#include <fstream>
+#include <thread>
+#include <unistd.h>
+#include <vector>
+#include <atomic>
+#include <string>
+#include <mutex>
+#include <condition_variable>
+#include <future>
+#include <memory>
+#include <bpf/bpf.h>
+#include <filesystem>
+#include <chrono>
+
+#define PATH_MAX 4096
+
+union Rule
+{
+	char path[PATH_MAX];
+	struct
+	{
+		uint64_t not_inode; // used for judging whether it's inode filter
+		uint64_t inode;
+		dev_t dev; // 设备号
+	};
+};
+struct Test_Event
+{
+	char path[PATH_MAX];
+	uint64_t inode;
+	dev_t dev; // 设备号
+	uid_t uid;
+	pid_t pid;
+	int fd;
+	char comm[16];
+};
+struct BpfData
+{
+	uid_t uid;
+	pid_t pid;
+	int fd;
+	char comm[16];
+};
+struct LsofFds
+{
+	int filter_fd;
+	int logs_fd;
+};
+struct LsofSync
+{
+	std::mutex m;
+	std::condition_variable cv;
+	bool init_done = false;
+	bool exit_requested = false;
+};
+struct LsofRuntime
+{
+	LsofSync sync;
+	std::promise<LsofFds> fds_promise;
+	std::atomic<bool> *exit_flag = nullptr;
+};
+extern std::shared_ptr<LsofRuntime> lsof_init(FILE *output);
+extern void lsof_deinit();
+extern int lsof_main(int argc, char *args[]);
+extern long bpf_for_each_map_elem(int fd, void *callback_fn, void *callback_ctx, unsigned long long flags);
+
+#define TEST_EVENT_MAX 32
+static Test_Event g_test_events[TEST_EVENT_MAX] = {};
+static size_t g_test_event_count = 0;
+
+extern int ring_buffer__push(int fd, void *data, size_t sz);
+static long match_call(struct bpf_map *map, const void *key, void *value, void *ctx)
+{
+	struct Test_Event *test_event = (struct Test_Event *)ctx;
+    union Rule *rule = (union Rule *)value;
+	if (rule->not_inode)
+	{
+		if (strncmp(test_event->path, rule->path, sizeof(rule->path)))
+		{
+			return 0;
+		}
+	}
+	else
+	{
+		// 使用设备号进行比较
+		if (rule->dev != test_event->dev)
+		{
+			return 0;
+		}
+		if (rule->inode != test_event->inode)
+		{
+			return 0;
+		}
+	}
+	return 1;
+}
+static bool rules_filter(int filter_fd, struct Test_Event &event)
+{
+    return bpf_for_each_map_elem(filter_fd, (void *)match_call, &event, 0) == 1;
+}
+static void event_worker(
+    Test_Event *test_events,
+    size_t test_event_count,
+    std::shared_ptr<LsofRuntime> runtime,
+    std::future<LsofFds> fds_future
+)
+{
+    bool should_exit = false;
+    {
+        std::unique_lock<std::mutex> lock(runtime->sync.m);
+            runtime->sync.cv.wait(lock, [&] {
+            return runtime->sync.init_done || runtime->sync.exit_requested;
+        });
+        should_exit = runtime->sync.exit_requested;
+    }
+    if(should_exit)
+    {
+        *runtime->exit_flag = true;
+        return;
+    }
+   auto request_exit = [&]() {
+        std::lock_guard<std::mutex> lock(runtime->sync.m);
+        runtime->sync.exit_requested = true;
+        runtime->sync.cv.notify_all();
+        *runtime->exit_flag = true;
+    };
+    if (fds_future.wait_for(std::chrono::seconds(5)) != std::future_status::ready)
+    {
+        request_exit();
+        return;
+    }
+    LsofFds fds;
+    try
+    {
+        fds = fds_future.get();
+    }
+    catch (const std::future_error &)
+    {
+        request_exit();
+        return;
+    }
+    auto filter_fd = fds.filter_fd;
+    auto logs_fd = fds.logs_fd;
+    for(size_t i = 0; i < test_event_count; ++i)
+    {
+        auto &e = test_events[i];
+        if(rules_filter(filter_fd, e)){
+           struct BpfData log_data = {};
+           log_data.uid = e.uid;
+		   log_data.pid = e.pid;
+		   log_data.fd = e.fd;
+		   strncpy(log_data.comm, e.comm, sizeof(log_data.comm) - 1);
+		   ring_buffer__push(logs_fd, &log_data, sizeof(log_data));
+        }    
+    }
+    request_exit();
+}
+class LsofTest : public ::testing::Test
+{
+    protected:
+        const std::string TEST_ROOT = "/tmp/lsof_test_dir";
+        const std::string TEST_LOG_FILE = TEST_ROOT + "/log.txt";
+        std::shared_ptr<LsofRuntime> runtime;
+
+        void SetUp() override
+        {
+            createTestFiles();
+            memset(g_test_events, 0, sizeof(g_test_events));
+            g_test_event_count = 0;
+        }
+        void TearDown() override
+        {
+            cleanTestFiles();
+        }
+        void createTestFiles()
+        {
+             mkdir(TEST_ROOT.c_str(), 0755);
+        }
+        void cleanTestFiles()
+        {
+            std::filesystem::remove_all(TEST_ROOT);
+        }
+        bool existStr(const std::string &str)
+        {
+            std::ifstream file(TEST_LOG_FILE, std::ios::binary | std::ios::ate);
+            if(!file.is_open())
+            {
+                return false;
+            }
+            std::streamsize size = file.tellg();
+            file.seekg(0, std::ios::beg);
+            std::string content(size, '\0');
+            if(!file.read(&content[0],size)){
+                return false;
+            }
+            return content.find(str) != std::string::npos;
+        }
+          std::string readLog()
+        {
+            std::ifstream file(TEST_LOG_FILE, std::ios::binary | std::ios::ate);
+            if (!file.is_open())
+            {
+                return "";
+            }
+
+            std::streamsize size = file.tellg();
+            file.seekg(0, std::ios::beg);
+
+            std::string content(size, '\0');
+            if (!file.read(&content[0], size))
+            {
+                return "";
+            }
+            return content;
+        }
+        int countStr(const std::string &str)
+        {
+            std::ifstream file(TEST_LOG_FILE, std::ios::binary | std::ios::ate);
+            if(!file.is_open())
+            {
+                return -1;
+            }
+            std::streamsize size = file.tellg();
+            file.seekg(0, std::ios::beg);
+            std::string content(size, '\0');
+            if(!file.read(&content[0],size)){
+                return -1;
+            }
+            int count = 0;
+            size_t pos = 0;
+            while((pos = content.find(str, pos)) != std::string::npos) {
+                ++count;
+                pos += str.length();
+            }
+            return count;
+        }
+        void addTestEvent(const char *path, uint64_t inode, dev_t dev, uid_t uid, pid_t pid, int fd, const char *comm){
+            struct Test_Event e = {
+                .inode = inode,
+				.dev = dev,
+				.uid = uid,
+				.pid = pid,
+                .fd = fd,
+            };
+            if (path != nullptr) {
+                strncpy(e.path, path, sizeof(e.path) - 1);
+                e.path[sizeof(e.path) - 1] = '\0';
+            } else {
+                e.path[0] = '\0'; // 如果为空，设为空字符串
+            }
+			if (comm != nullptr) {
+                strncpy(e.comm, comm, sizeof(e.comm) - 1);
+                e.comm[sizeof(e.comm) - 1] = '\0';
+            } else {
+                e.comm[0] = '\0'; // 如果为空，设为空字符串
+            }
+            ASSERT_LT(g_test_event_count, (size_t)TEST_EVENT_MAX);
+            g_test_events[g_test_event_count++] = e;
+        }
+        int runLsof(const std::vector<std::string> &_args){
+            std::vector<std::string> t;
+            t.push_back("lsof");
+            t.insert(t.end(),_args.begin(), _args.end());
+            std::vector<char *> argv;
+            argv.reserve(t.size());
+            for(const auto &arg : t){
+                argv.push_back(const_cast<char *>(arg.c_str()));
+            }
+            FILE *log_file = fopen(TEST_LOG_FILE.c_str(),"w");
+            if (!log_file) 
+            {
+                ADD_FAILURE() << "Failed to create log file";
+                return -1;
+            }
+            runtime = lsof_init(log_file);
+            std::future<LsofFds> fds_future = runtime->fds_promise.get_future();
+            std::thread event_thread(
+                event_worker,
+                g_test_events,
+                g_test_event_count,
+                runtime,
+                std::move(fds_future));
+        int ret = lsof_main(argv.size(), argv.data());
+            {
+                std::lock_guard<std::mutex> lock(runtime->sync.m);
+                runtime->sync.exit_requested = true;
+            }
+            runtime->sync.cv.notify_all();
+            event_thread.join();
+            lsof_deinit();
+            fclose(log_file);
+            return ret;
+        }
+};
+//SimpleTest1
+TEST_F(LsofTest, SimpleTest1)
+{
+    runLsof({"-h"});
+    EXPECT_TRUE(existStr("Usage:"));
+}
+//测试能否正常输出
+TEST_F(LsofTest, SimpleTest2)
+{
+	addTestEvent("/tmp/tail.txt", 1, 2, 24812, 709769, 3, "tail");
+    runLsof({"-p", "/tmp/tail.txt"});
+    EXPECT_TRUE(existStr("Scanning for file /tmp/tail.txt..."));
+	EXPECT_TRUE(existStr("tail  24812   709769   3"));
+}
+//测试-p path能否正常过滤
+TEST_F(LsofTest, PathFilterApplied)
+{
+	addTestEvent("/tmp/tail.txt", 1, 2, 24812, 709769, 3, "tail");
+	addTestEvent("/tmp/vma.txt", 2, 4, 24812, 710069,3, "python3");
+    runLsof({"-p", "/tmp/vma.txt"});
+    EXPECT_TRUE(!existStr("Scanning for file /tmp/tail.txt..."));
+	EXPECT_TRUE(!existStr("tail  24812   709769   3"));
+	EXPECT_TRUE(existStr("Scanning for file /tmp/vma.txt..."));
+	EXPECT_TRUE(existStr("python3  24812   710069   3"));
+}
+//测试-d dev -i inode能否正常过滤
+TEST_F(LsofTest, DevAndInodeFilterApplied)
+{
+	addTestEvent("/tmp/tail.txt", 1, 2, 24812, 709769, 3, "tail");
+	addTestEvent("/tmp/vma.txt", 2, 4, 24812, 710069,3, "python3");
+    runLsof({"-d", "2", "-i", "1"});
+    EXPECT_TRUE(existStr("Scanning for file ..."));
+	EXPECT_TRUE(existStr("tail  24812   709769   3"));
+	EXPECT_TRUE(!existStr("python3  24812   710069   3 4 vma(1)"));
+}
+
+// 测试 -p 传空字符串时应报错
+TEST_F(LsofTest, EmptyPathRejected)
+{
+	EXPECT_EQ(runLsof({"-p", ""}), -1);
+	EXPECT_TRUE(existStr("error: -p requires a non-empty path"));
+}
+
+// 测试 -d 传非数字时应报错
+TEST_F(LsofTest, InvalidDevAlphaRejected)
+{
+	EXPECT_EQ(runLsof({"-d", "abc", "-i", "1"}), -1);
+	EXPECT_TRUE(existStr("error: invalid dev value: abc"));
+}
+
+// 测试 -d 传混合字符串时应报错
+TEST_F(LsofTest, InvalidDevMixedRejected)
+{
+	EXPECT_EQ(runLsof({"-d", "12abc", "-i", "1"}), -1);
+	EXPECT_TRUE(existStr("error: invalid dev value: 12abc"));
+}
+
+// 测试 -i 传非数字时应报错
+TEST_F(LsofTest, InvalidInodeAlphaRejected)
+{
+	EXPECT_EQ(runLsof({"-d", "2", "-i", "abc"}), -1);
+	EXPECT_TRUE(existStr("error: invalid inode value: abc"));
+}
+
+// 测试 -i 传混合字符串时应报错
+TEST_F(LsofTest, InvalidInodeMixedRejected)
+{
+	EXPECT_EQ(runLsof({"-d", "2", "-i", "12abc"}), -1);
+	EXPECT_TRUE(existStr("error: invalid inode value: 12abc"));
+}
+
+// 测试仅传 -d 时应报错
+TEST_F(LsofTest, MissingInodeRejected)
+{
+	EXPECT_EQ(runLsof({"-d", "2"}), -1);
+	EXPECT_TRUE(existStr("error: -d and -i must be used together"));
+}
+
+// 测试仅传 -i 时应报错
+TEST_F(LsofTest, MissingDevRejected)
+{
+	EXPECT_EQ(runLsof({"-i", "1"}), -1);
+	EXPECT_TRUE(existStr("error: -d and -i must be used together"));
+}
+
+// 测试 -p 和 -d/-i 混用时应报错
+TEST_F(LsofTest, PathAndDevInodeMixedRejected)
+{
+	EXPECT_EQ(runLsof({"-p", "/tmp/tail.txt", "-d", "2", "-i", "1"}), -1);
+	EXPECT_TRUE(existStr("error: -p can't be used together with -d/-i"));
+}

--- a/test/mock.cpp
+++ b/test/mock.cpp
@@ -68,6 +68,7 @@ struct bpf_map
 	size_t value_size;
 	size_t max_entries;
 	size_t sz;
+	size_t mmap_sz;
 	void *mem;
 	bpf_map_type type;
 	std::string name;
@@ -81,6 +82,15 @@ struct bpf_object
 	std::vector<bpf_link> links;
 };
 
+struct skeleton_offsets
+{
+	size_t map_base;
+	size_t prog_base;
+	size_t link_base;
+	int map_cnt;
+	int prog_cnt;
+};
+
 struct ring_buffer
 {
 	int map_fd;
@@ -90,6 +100,7 @@ struct ring_buffer
 };
 
 static bpf_object g_obj;
+static std::map<const bpf_object_skeleton *, skeleton_offsets> g_skeleton_offsets;
 
 std::string fd_path(int fd)
 {
@@ -293,22 +304,52 @@ void bpf_object__destroy_skeleton(struct bpf_object_skeleton *s)
 		return;
 	}
 
-	int fd;
-	char buf[PATH_MAX];
-
-	for (int i = 0; i < s->prog_cnt; i++)
+	auto offset_it = g_skeleton_offsets.find(s);
+	if (offset_it == g_skeleton_offsets.end())
 	{
-		close(g_obj.progs[i].fd);
-		close(g_obj.links[i].fd);
+		free(s->maps);
+		free(s->progs);
+		free(s);
+		return;
 	}
-	g_obj.progs.clear();
-	g_obj.links.clear();
+	const skeleton_offsets offsets = offset_it->second;
+
 	for (int i = 0; i < s->map_cnt; i++)
 	{
-		munmap(g_obj.maps[i].mem, g_obj.maps[i].sz);
-		close(g_obj.maps[i].fd);
+		if (s->maps[i].mmaped && *s->maps[i].mmaped)
+		{
+			free(*s->maps[i].mmaped);
+			*s->maps[i].mmaped = nullptr;
+		}
 	}
-	g_obj.maps.clear();
+
+	for (int i = 0; i < offsets.prog_cnt; i++)
+	{
+		close(g_obj.progs[offsets.prog_base + i].fd);
+		close(g_obj.links[offsets.link_base + i].fd);
+	}
+	g_obj.progs.erase(
+		g_obj.progs.begin() + offsets.prog_base,
+		g_obj.progs.begin() + offsets.prog_base + offsets.prog_cnt
+	);
+	g_obj.links.erase(
+		g_obj.links.begin() + offsets.link_base,
+		g_obj.links.begin() + offsets.link_base + offsets.prog_cnt
+	);
+	for (int i = 0; i < offsets.map_cnt; i++)
+	{
+		bpf_map &map = g_obj.maps[offsets.map_base + i];
+		if (map.mem)
+		{
+			munmap(map.mem, map.mmap_sz ? map.mmap_sz : map.sz);
+		}
+		close(map.fd);
+	}
+	g_obj.maps.erase(
+		g_obj.maps.begin() + offsets.map_base,
+		g_obj.maps.begin() + offsets.map_base + offsets.map_cnt
+	);
+	g_skeleton_offsets.erase(offset_it);
 	free(s->maps);
 	free(s->progs);
 	free(s);
@@ -319,7 +360,7 @@ int bpf_object__find_map_fd_by_name(
 	const char *name
 )
 {
-	for (int i = 0; i < obj->maps.size(); i++)
+	for (int i = (int)obj->maps.size() - 1; i >= 0; i--)
 	{
 		if (obj->maps[i].name == name)
 		{
@@ -345,15 +386,21 @@ int bpf_object__open_skeleton(
 
 	*s->obj = &g_obj;
 
+	const size_t map_base = g_obj.maps.size();
+	const size_t prog_base = g_obj.progs.size();
+	const size_t link_base = g_obj.links.size();
+	g_obj.maps.reserve(map_base + s->map_cnt);
+	g_obj.progs.reserve(prog_base + s->prog_cnt);
+	g_obj.links.reserve(link_base + s->prog_cnt);
+	g_skeleton_offsets[s] = {map_base, prog_base, link_base, s->map_cnt, s->prog_cnt};
+
 	int fd;
-	bpf_program prog;
-	bpf_map map;
-	bpf_link link;
 	const char *name;
 	char buf[PATH_MAX];
 
 	for (int i = 0; i < s->map_cnt; i++)
 	{
+		bpf_map map {};
 		name = s->maps[i].name;
 		snprintf(buf, PATH_MAX, "%s/map-%s", BPF_PIN_PATH, name);
 		fd = open(buf, O_RDWR | O_TRUNC | O_CREAT, 0600);
@@ -378,35 +425,43 @@ int bpf_object__open_skeleton(
 			map.sz = RB_MAP_SIZE;
 			map.type = BPF_MAP_TYPE_UNSPEC;
 		}
+		map.mmap_sz = 0;
 		int page_size = getpagesize();
 		if (strcmp(name, "dk_shared_mem") == 0 ||
 			map.type == BPF_MAP_TYPE_RINGBUF)
 		{
 			int ret = 0;
-			ret = ftruncate(fd, page_size * 2 + RB_MAP_SIZE);
+			map.mmap_sz = page_size * 2 + RB_MAP_SIZE;
+			ret = ftruncate(fd, map.mmap_sz);
 			assert(ret == 0);
 			map.type = BPF_MAP_TYPE_RINGBUF;
 			map.mem = mmap(
 				NULL,
-				page_size * 2 + RB_MAP_SIZE,
+				map.mmap_sz,
 				PROT_READ | PROT_WRITE,
 				MAP_SHARED,
 				fd,
 				0
 			);
 			assert(map.mem != MAP_FAILED);
-			memset(map.mem, 0, page_size * 2 + RB_MAP_SIZE);
+			memset(map.mem, 0, map.mmap_sz);
 		}
 		else
 		{
 			map.mem = nullptr;
 		}
 		g_obj.maps.push_back(std::move(map));
-		*s->maps[i].map = &g_obj.maps[i];
+		*s->maps[i].map = &g_obj.maps[map_base + i];
+		if (s->maps[i].mmaped)
+		{
+			*s->maps[i].mmaped = calloc(1, getpagesize());
+			assert(*s->maps[i].mmaped != nullptr);
+		}
 	}
 
 	for (int i = 0; i < s->prog_cnt; i++)
 	{
+		bpf_program prog {};
 		name = s->progs[i].name;
 		snprintf(buf, PATH_MAX, "%s/prog-%s", BPF_PIN_PATH, name);
 		fd = open(buf, O_RDWR | O_TRUNC | O_CREAT, 0600);
@@ -432,8 +487,9 @@ int bpf_object__open_skeleton(
 			}
 		}
 		g_obj.progs.push_back(std::move(prog));
-		*s->progs[i].prog = &g_obj.progs[i];
+		*s->progs[i].prog = &g_obj.progs[prog_base + i];
 
+		bpf_link link {};
 		snprintf(buf, PATH_MAX, "%s/link-%s", BPF_PIN_PATH, name);
 		fd = open(buf, O_RDWR | O_TRUNC | O_CREAT, 0600);
 		if (fd < 0)
@@ -442,9 +498,9 @@ int bpf_object__open_skeleton(
 		}
 		link.fd = fd;
 		link.pin_path = buf;
-		link.prog = &g_obj.progs[i];
+		link.prog = &g_obj.progs[prog_base + i];
 		g_obj.links.push_back(std::move(link));
-		*s->progs[i].link = &g_obj.links[i];
+		*s->progs[i].link = &g_obj.links[link_base + i];
 	}
 	return 0;
 }


### PR DESCRIPTION
### 本次修改集中在 test 目录，修改内容如下

1.添加了 lsof 的 BUILTIN 单测。测试内容围绕工具实际功能补充了较完整的回归验证，覆盖了以下几类行为：

- 测试能否正常输出
- 测试-p path能否正常过滤
- 测试-d dev -i inode能否正常过滤
- 测试 -p 传空字符串时应报错
- 测试 -d 传非数字时应报错
- 测试 -d 传混合字符串时应报错
- 测试 -i 传非数字时应报错
- 测试 -i 传混合字符串时应报错
- 测试仅传 -d 时应报错
- 测试仅传 -i 时应报错
- 测试 -p 和 -d/-i 混用时应报错

2.在test/Makefile 中补齐测试目标的链接依赖；

3.在test/mock.cpp 中修正 skeleton 对象在全局容器中的分配、指针回填和销毁逻辑，避免因扩容和错索引导致的崩溃；

