### PR TITLE
test: add pagefault testing and builtin coverage for pagefault tool

### DIFF
--- a/test/Makefile
+++ b/test/Makefile
@@ -23,7 +23,8 @@ CXXFLAGS = -g -D__GTEST__ -DBUILTIN -MMD \
 		   -I$(PROJ_ROOT)/build/policy \
 		   -I$(PROJ_ROOT)/bpf/export
 
-LDFLAGS = -Wl,-rpath=$(PROJ_ROOT)/googletest/build/lib/
+LDFLAGS = -Wl,-rpath='$$ORIGIN/../../googletest/build/lib' #-fsanitize=address
+LDLIBS = -lbpf -lpthread -lelf -lz
 
 GTEST_LIBS = $(PROJ_ROOT)/googletest/build/lib/libgtest_main.so	\
 			 $(PROJ_ROOT)/googletest/build/lib/libgtest.so
@@ -43,9 +44,10 @@ $(TARGET): $(OBJS) $(GTEST_LIBS) \
 	$(BUILD_DIR)/kmemleak.o \
 	$(BUILD_DIR)/irqsnoop.o \
 	$(BUILD_DIR)/mountsnoop.o \
+	$(BUILD_DIR)/pagefault.o \
 	$(BUILD_DIR)/frtp.o \
 	$(BUILD_DIR)/elfverify.o
-	$(CXX) $^ $(LDFLAGS) -o $@
+	$(CXX) $^ $(LDFLAGS) $(LDLIBS) -o $@
 
 $(BUILD_DIR):
 	@mkdir -p $@

--- a/test/mock-data-generator.h
+++ b/test/mock-data-generator.h
@@ -14,7 +14,12 @@
 #include <vector>
 #include <cstring>
 #include <cstdlib>
-
+//生成模拟栈信息
+struct MockStackCtx
+{
+	std::vector<__u64> user_ips;
+	std::vector<__u64> kernel_ips;
+};
 /**
  * @brief 生成模拟进程数据，用于测试和演示
  * @param num_processes 要生成的进程数量

--- a/test/mock.cpp
+++ b/test/mock.cpp
@@ -59,6 +59,7 @@ struct bpf_program
 	std::string pin_path;
 	bpf_map *map;
 	void (*function)(bpf_program *p);
+	bool autoload;
 };
 
 struct bpf_map
@@ -68,6 +69,7 @@ struct bpf_map
 	size_t value_size;
 	size_t max_entries;
 	size_t sz;
+	size_t mmap_sz;
 	void *mem;
 	bpf_map_type type;
 	std::string name;
@@ -81,6 +83,15 @@ struct bpf_object
 	std::vector<bpf_link> links;
 };
 
+struct skeleton_offsets
+{
+	size_t map_base;
+	size_t prog_base;
+	size_t link_base;
+	int map_cnt;
+	int prog_cnt;
+};
+
 struct ring_buffer
 {
 	int map_fd;
@@ -90,6 +101,120 @@ struct ring_buffer
 };
 
 static bpf_object g_obj;
+static std::map<const bpf_object_skeleton *, skeleton_offsets> g_skeleton_offsets;
+static __u32 g_next_stack_id = 0;
+
+static void recalc_map_storage(struct bpf_map *map)
+{
+	if (!map)
+	{
+		return;
+	}
+
+	if (map->type == BPF_MAP_TYPE_RINGBUF)
+	{
+		return;
+	}
+
+	if (map->key_size == 0 || map->value_size == 0 || map->max_entries == 0)
+	{
+		map->sz = 0;
+		return;
+	}
+
+	map->sz = (map->key_size + map->value_size) * map->max_entries;
+}
+
+static struct bpf_map *find_map_by_fd(int fd)
+{
+	for (auto &map : g_obj.maps)
+	{
+		if (map.fd == fd)
+		{
+			return &map;
+		}
+	}
+	return nullptr;
+}
+
+static int fill_mock_stack_trace_from_values(
+	struct bpf_map *map,
+	__u32 stack_id,
+	const __u64 *ips_src,
+	size_t ips_cnt
+)
+{
+	if (!map || map->type != BPF_MAP_TYPE_STACK_TRACE)
+	{
+		return -EINVAL;
+	}
+
+	if (map->value_size < sizeof(__u64))
+	{
+		return -EINVAL;
+	}
+
+	const size_t depth = map->value_size / sizeof(__u64);
+	std::vector<__u64> ips(depth, 0);
+	const size_t nr_frames = ips_cnt < depth ? ips_cnt : depth;
+
+	for (size_t i = 0; i < nr_frames; i++)
+	{
+		ips[i] = ips_src[i];
+	}
+
+	return bpf_map_update_elem(map->fd, &stack_id, ips.data(), BPF_ANY);
+}
+
+static int fill_mock_stack_trace(
+	struct bpf_map *map,
+	__u32 stack_id,
+	void *ctx,
+	__u64 flags
+)
+{
+	const MockStackCtx *stack_ctx =
+		static_cast<const MockStackCtx *>(ctx);
+	if (stack_ctx)
+	{
+		const std::vector<__u64> &src =
+			(flags & BPF_F_USER_STACK) ? stack_ctx->user_ips : stack_ctx->kernel_ips;
+		const __u64 skip = flags & BPF_F_SKIP_FIELD_MASK;
+		if (src.size() > skip)
+		{
+			return fill_mock_stack_trace_from_values(
+				map,
+				stack_id,
+				src.data() + skip,
+				src.size() - skip
+			);
+		}
+	}
+
+	if (!map || map->type != BPF_MAP_TYPE_STACK_TRACE)
+	{
+		return -EINVAL;
+	}
+
+	if (map->value_size < sizeof(__u64))
+	{
+		return -EINVAL;
+	}
+
+	const size_t depth = map->value_size / sizeof(__u64);
+	std::vector<__u64> ips(depth, 0);
+	const __u64 skip = flags & BPF_F_SKIP_FIELD_MASK;
+	const __u64 base = (flags & BPF_F_USER_STACK) ? 0x00007fff00000000ULL
+												  : 0xffffffff80000000ULL;
+	const size_t nr_frames = depth < 8 ? depth : 8;
+
+	for (size_t i = 0; i < nr_frames; i++)
+	{
+		ips[i] = base + ((stack_id + 1) * 0x1000ULL) + ((skip + i + 1) * 0x10ULL);
+	}
+
+	return bpf_map_update_elem(map->fd, &stack_id, ips.data(), BPF_ANY);
+}
 
 std::string fd_path(int fd)
 {
@@ -195,7 +320,9 @@ int bpf_map_get_info_by_fd(
 		if (g_obj.maps[i].fd == map_fd)
 		{
 			info->type = g_obj.maps[i].type;
-			info->max_entries = g_obj.maps[i].sz;
+			info->key_size = g_obj.maps[i].key_size;
+			info->value_size = g_obj.maps[i].value_size;
+			info->max_entries = g_obj.maps[i].max_entries;
 			sprintf(info->name, "%s", g_obj.maps[i].name.c_str());
 			return 0;
 		}
@@ -265,9 +392,19 @@ int bpf_program__unpin(struct bpf_program *prog, const char *path)
 	return 0;
 }
 
+int bpf_program__set_autoload(struct bpf_program *prog, bool autoload)
+{
+	if (!prog)
+	{
+		return -EINVAL;
+	}
+	prog->autoload = autoload;
+	return 0;
+}
+
 bool bpf_program__autoload(const struct bpf_program *prog)
 {
-	return true;
+	return prog ? prog->autoload : false;
 }
 
 int bpf_object__pin_maps(struct bpf_object *obj, const char *path)
@@ -293,22 +430,56 @@ void bpf_object__destroy_skeleton(struct bpf_object_skeleton *s)
 		return;
 	}
 
-	int fd;
-	char buf[PATH_MAX];
-
-	for (int i = 0; i < s->prog_cnt; i++)
+	auto offset_it = g_skeleton_offsets.find(s);
+	if (offset_it == g_skeleton_offsets.end())
 	{
-		close(g_obj.progs[i].fd);
-		close(g_obj.links[i].fd);
+		free(s->maps);
+		free(s->progs);
+		free(s);
+		return;
 	}
-	g_obj.progs.clear();
-	g_obj.links.clear();
+	const skeleton_offsets offsets = offset_it->second;
+
 	for (int i = 0; i < s->map_cnt; i++)
 	{
-		munmap(g_obj.maps[i].mem, g_obj.maps[i].sz);
-		close(g_obj.maps[i].fd);
+		if (s->maps[i].mmaped && *s->maps[i].mmaped)
+		{
+			free(*s->maps[i].mmaped);
+			*s->maps[i].mmaped = nullptr;
+		}
 	}
-	g_obj.maps.clear();
+
+	for (int i = 0; i < offsets.prog_cnt; i++)
+	{
+		close(g_obj.progs[offsets.prog_base + i].fd);
+		close(g_obj.links[offsets.link_base + i].fd);
+	}
+	g_obj.progs.erase(
+		g_obj.progs.begin() + offsets.prog_base,
+		g_obj.progs.begin() + offsets.prog_base + offsets.prog_cnt
+	);
+	g_obj.links.erase(
+		g_obj.links.begin() + offsets.link_base,
+		g_obj.links.begin() + offsets.link_base + offsets.prog_cnt
+	);
+	for (int i = 0; i < offsets.map_cnt; i++)
+	{
+		bpf_map &map = g_obj.maps[offsets.map_base + i];
+		if (map.mem)
+		{
+			munmap(map.mem, map.mmap_sz ? map.mmap_sz : map.sz);
+		}
+		close(map.fd);
+	}
+	g_obj.maps.erase(
+		g_obj.maps.begin() + offsets.map_base,
+		g_obj.maps.begin() + offsets.map_base + offsets.map_cnt
+	);
+	if (g_obj.maps.empty())
+	{
+		g_next_stack_id = 0;
+	}
+	g_skeleton_offsets.erase(offset_it);
 	free(s->maps);
 	free(s->progs);
 	free(s);
@@ -319,7 +490,7 @@ int bpf_object__find_map_fd_by_name(
 	const char *name
 )
 {
-	for (int i = 0; i < obj->maps.size(); i++)
+	for (int i = (int)obj->maps.size() - 1; i >= 0; i--)
 	{
 		if (obj->maps[i].name == name)
 		{
@@ -345,15 +516,21 @@ int bpf_object__open_skeleton(
 
 	*s->obj = &g_obj;
 
+	const size_t map_base = g_obj.maps.size();
+	const size_t prog_base = g_obj.progs.size();
+	const size_t link_base = g_obj.links.size();
+	g_obj.maps.reserve(map_base + s->map_cnt);
+	g_obj.progs.reserve(prog_base + s->prog_cnt);
+	g_obj.links.reserve(link_base + s->prog_cnt);
+	g_skeleton_offsets[s] = {map_base, prog_base, link_base, s->map_cnt, s->prog_cnt};
+
 	int fd;
-	bpf_program prog;
-	bpf_map map;
-	bpf_link link;
 	const char *name;
 	char buf[PATH_MAX];
 
 	for (int i = 0; i < s->map_cnt; i++)
 	{
+		bpf_map map {};
 		name = s->maps[i].name;
 		snprintf(buf, PATH_MAX, "%s/map-%s", BPF_PIN_PATH, name);
 		fd = open(buf, O_RDWR | O_TRUNC | O_CREAT, 0600);
@@ -377,36 +554,46 @@ int bpf_object__open_skeleton(
 		{
 			map.sz = RB_MAP_SIZE;
 			map.type = BPF_MAP_TYPE_UNSPEC;
+			map.max_entries = RB_MAP_SIZE;
 		}
+		map.mmap_sz = 0;
 		int page_size = getpagesize();
 		if (strcmp(name, "dk_shared_mem") == 0 ||
 			map.type == BPF_MAP_TYPE_RINGBUF)
 		{
 			int ret = 0;
-			ret = ftruncate(fd, page_size * 2 + RB_MAP_SIZE);
+			map.mmap_sz = page_size * 2 + RB_MAP_SIZE;
+			ret = ftruncate(fd, map.mmap_sz);
 			assert(ret == 0);
 			map.type = BPF_MAP_TYPE_RINGBUF;
+			map.max_entries = RB_MAP_SIZE;
 			map.mem = mmap(
 				NULL,
-				page_size * 2 + RB_MAP_SIZE,
+				map.mmap_sz,
 				PROT_READ | PROT_WRITE,
 				MAP_SHARED,
 				fd,
 				0
 			);
 			assert(map.mem != MAP_FAILED);
-			memset(map.mem, 0, page_size * 2 + RB_MAP_SIZE);
+			memset(map.mem, 0, map.mmap_sz);
 		}
 		else
 		{
 			map.mem = nullptr;
 		}
 		g_obj.maps.push_back(std::move(map));
-		*s->maps[i].map = &g_obj.maps[i];
+		*s->maps[i].map = &g_obj.maps[map_base + i];
+		if (s->maps[i].mmaped)
+		{
+			*s->maps[i].mmaped = calloc(1, getpagesize());
+			assert(*s->maps[i].mmaped != nullptr);
+		}
 	}
 
 	for (int i = 0; i < s->prog_cnt; i++)
 	{
+		bpf_program prog {};
 		name = s->progs[i].name;
 		snprintf(buf, PATH_MAX, "%s/prog-%s", BPF_PIN_PATH, name);
 		fd = open(buf, O_RDWR | O_TRUNC | O_CREAT, 0600);
@@ -419,6 +606,7 @@ int bpf_object__open_skeleton(
 		prog.name = name;
 		prog.map = nullptr;
 		prog.function = nullptr;
+		prog.autoload = true;
 		if (strcmp(name, "dump_task") == 0)
 		{
 			prog.function = dump_task;
@@ -432,8 +620,9 @@ int bpf_object__open_skeleton(
 			}
 		}
 		g_obj.progs.push_back(std::move(prog));
-		*s->progs[i].prog = &g_obj.progs[i];
+		*s->progs[i].prog = &g_obj.progs[prog_base + i];
 
+		bpf_link link {};
 		snprintf(buf, PATH_MAX, "%s/link-%s", BPF_PIN_PATH, name);
 		fd = open(buf, O_RDWR | O_TRUNC | O_CREAT, 0600);
 		if (fd < 0)
@@ -442,9 +631,9 @@ int bpf_object__open_skeleton(
 		}
 		link.fd = fd;
 		link.pin_path = buf;
-		link.prog = &g_obj.progs[i];
+		link.prog = &g_obj.progs[prog_base + i];
 		g_obj.links.push_back(std::move(link));
-		*s->progs[i].link = &g_obj.links[i];
+		*s->progs[i].link = &g_obj.links[link_base + i];
 	}
 	return 0;
 }
@@ -593,15 +782,7 @@ int bpf_map_update_elem(int fd, const void *key, const void *value, __u64 flags)
 	{
 		return 0;
 	}
-	struct bpf_map *map = nullptr;
-	for (auto &i : g_obj.maps)
-	{
-		if (i.fd == fd)
-		{
-			map = &i;
-			break;
-		}
-	}
+	struct bpf_map *map = find_map_by_fd(fd);
 	if (!map)
 	{
 		return 0;
@@ -660,13 +841,25 @@ struct ring_buffer *ring_buffer__new(
 
 int bpf_map__set_value_size(struct bpf_map *map, __u32 size)
 {
-	map->sz = size;
+	if (!map)
+	{
+		return -EINVAL;
+	}
+
+	map->value_size = size;
+	recalc_map_storage(map);
 	return 0;
 }
 
 int bpf_map__set_max_entries(struct bpf_map *map, __u32 max_entries)
 {
+	if (!map)
+	{
+		return -EINVAL;
+	}
+
 	map->max_entries = max_entries;
+	recalc_map_storage(map);
 	return 0;
 }
 
@@ -681,15 +874,7 @@ int bpf_map_lookup_elem(int fd, const void *key, void *value)
 	{
 		return 0;
 	}
-	struct bpf_map *map = nullptr;
-	for (auto &i : g_obj.maps)
-	{
-		if (i.fd == fd)
-		{
-			map = &i;
-			break;
-		}
-	}
+	struct bpf_map *map = find_map_by_fd(fd);
 	if (!map)
 	{
 		return 0;
@@ -704,6 +889,38 @@ int bpf_map_lookup_elem(int fd, const void *key, void *value)
 	lseek(fd, pos + map->key_size, SEEK_SET);
 	read(fd, value, map->value_size);
 	return 0;
+}
+
+long bpf_get_stackid(void *ctx, struct bpf_map *map, __u64 flags)
+{
+	if (!map)
+	{
+		return -EINVAL;
+	}
+
+	if (map->type != BPF_MAP_TYPE_STACK_TRACE)
+	{
+		return -EINVAL;
+	}
+
+	if (map->max_entries == 0)
+	{
+		return -E2BIG;
+	}
+
+	__u32 stack_id = g_next_stack_id++;
+	if (stack_id >= map->max_entries)
+	{
+		g_next_stack_id = map->max_entries;
+		return -E2BIG;
+	}
+
+	if (fill_mock_stack_trace(map, stack_id, ctx, flags) < 0)
+	{
+		return -EFAULT;
+	}
+
+	return stack_id;
 }
 
 int bpf_map_get_next_key(int fd, const void *key, void *next_key)
@@ -908,7 +1125,7 @@ ssize_t read(int __fd, void *__buf, size_t __nbytes)
 		}
 
 		bpf_program *prog = g_obj.links[i].prog;
-		if (prog->function)
+		if (prog->autoload && prog->function)
 		{
 			prog->function(prog);
 		}

--- a/test/pagefault-test.cpp
+++ b/test/pagefault-test.cpp
@@ -1,0 +1,468 @@
+#include "gtest/gtest.h"
+#include <iostream>
+#include <fstream>
+#include <thread>
+#include <unistd.h>
+#include <vector>
+#include <atomic>
+#include <string>
+#include <mutex>
+#include <condition_variable>
+#include <future>
+#include <memory>
+#include <bpf/bpf.h>
+#include <filesystem>
+#include <chrono>
+#include "mock-data-generator.h"
+
+struct page_fault_t
+{
+	pid_t pid;
+	pid_t tid;
+	char comm[16];
+	int stack_id;
+	__u64 timestamp;
+	unsigned long address;
+	unsigned long ip;
+	unsigned long error_code;
+};
+
+struct PagefaultFds
+{
+	int filter_fd;
+	int events_fd;
+	int stack_traces_fd;
+};
+
+struct PagefaultSync
+{
+	std::mutex m;
+	std::condition_variable cv;
+	bool init_done = false;
+	bool exit_requested = false;
+};
+
+struct PagefaultRuntime
+{
+	PagefaultSync sync;
+	std::promise<PagefaultFds> fds_promise;
+	volatile bool *exit_flag = nullptr;
+	std::mutex consume_m;
+	std::condition_variable consume_cv;
+	size_t consumed = 0;
+};
+
+extern std::shared_ptr<PagefaultRuntime> pagefault_init(FILE *output);
+extern void pagefault_deinit();
+extern int pagefault_main(int argc, char **argv);
+extern long bpf_for_each_map_elem(
+	int fd,
+	void *callback_fn,
+	void *callback_ctx,
+	__u64 flags
+);
+extern int ring_buffer__push(int fd, void *data, size_t sz);
+
+#define TEST_EVENT_MAX 32
+#define PAGEFAULT_STACK_DEPTH 127
+
+struct PagefaultTestEvent
+{
+	enum EventType
+	{
+		EVENT_KERNEL,
+		EVENT_USER,
+	};
+	struct page_fault_t event;
+	EventType type;
+	bool has_stack;
+	MockStackCtx stack_ctx;
+};
+
+static PagefaultTestEvent g_test_events[TEST_EVENT_MAX] = {};
+static size_t g_test_event_count = 0;
+
+struct FilterCtx
+{
+	PagefaultTestEvent *event;
+	bool trace_user;
+	bool trace_kernel;
+};
+
+static long match_call(struct bpf_map *map, const void *key, void *value, void *ctx)
+{
+	struct FilterCtx *filter_ctx = (struct FilterCtx *)ctx;
+	PagefaultTestEvent *event = filter_ctx->event;
+	pid_t *rule = (pid_t *)value;
+	if (event->type == PagefaultTestEvent::EVENT_USER && !filter_ctx->trace_user)
+	{
+		return 0;
+	}
+	if (event->type == PagefaultTestEvent::EVENT_KERNEL && !filter_ctx->trace_kernel)
+	{
+		return 0;
+	}
+	if (*rule > 0 && event->event.pid != *rule)
+	{
+		return 0;
+	}
+	return 1;
+}
+
+static bool rules_filter(
+	int filter_fd,
+	PagefaultTestEvent &event,
+	bool trace_user,
+	bool trace_kernel
+)
+{
+	struct FilterCtx filter_ctx = {
+		.event = &event,
+		.trace_user = trace_user,
+		.trace_kernel = trace_kernel,
+	};
+
+	if (event.type == PagefaultTestEvent::EVENT_USER && !trace_user)
+	{
+		return false;
+	}
+	if (event.type == PagefaultTestEvent::EVENT_KERNEL && !trace_kernel)
+	{
+		return false;
+	}
+
+	int next_key = 0;
+	if (bpf_map_get_next_key(filter_fd, NULL, &next_key) == -ENOENT)
+	{
+		return true;
+	}
+
+	long ret =
+		bpf_for_each_map_elem(filter_fd, (void *)match_call, &filter_ctx, 0);
+	return ret == 1;
+}
+
+static void event_worker(
+	PagefaultTestEvent *test_events,
+	size_t test_event_count,
+	bool trace_user,
+	bool trace_kernel,
+	std::shared_ptr<PagefaultRuntime> runtime,
+	std::future<PagefaultFds> fds_future
+)
+{
+	bool should_exit = false;
+	{
+		std::unique_lock<std::mutex> lock(runtime->sync.m);
+		runtime->sync.cv.wait(lock, [&] {
+			return runtime->sync.init_done || runtime->sync.exit_requested;
+		});
+		should_exit = runtime->sync.exit_requested;
+	}
+	if (should_exit)
+	{
+		*runtime->exit_flag = true;
+		return;
+	}
+
+	auto request_exit = [&]() {
+		std::lock_guard<std::mutex> lock(runtime->sync.m);
+		runtime->sync.exit_requested = true;
+		runtime->sync.cv.notify_all();
+		*runtime->exit_flag = true;
+	};
+
+	if (fds_future.wait_for(std::chrono::seconds(5)) !=
+		std::future_status::ready)
+	{
+		request_exit();
+		return;
+	}
+
+	PagefaultFds fds;
+	try
+	{
+		fds = fds_future.get();
+	}
+	catch (const std::future_error &)
+	{
+		request_exit();
+		return;
+	}
+
+	size_t expected = 0;
+	for (size_t i = 0; i < test_event_count; ++i)
+	{
+		auto &e = test_events[i];
+		if (!rules_filter(fds.filter_fd, e, trace_user, trace_kernel))
+		{
+			continue;
+		}
+		if (e.has_stack && e.event.stack_id >= 0)
+		{
+			__u64 ips[PAGEFAULT_STACK_DEPTH] = {};
+			size_t nr = e.stack_ctx.user_ips.size();
+			if (nr > PAGEFAULT_STACK_DEPTH)
+			{
+				nr = PAGEFAULT_STACK_DEPTH;
+			}
+			for (size_t j = 0; j < nr; ++j)
+			{
+				ips[j] = e.stack_ctx.user_ips[j];
+			}
+			bpf_map_update_elem(
+				fds.stack_traces_fd,
+				&e.event.stack_id,
+				ips,
+				BPF_ANY
+			);
+		}
+		ring_buffer__push(fds.events_fd, &e.event, sizeof(e.event));
+		expected++;
+	}
+	{
+		std::unique_lock<std::mutex> lock(runtime->consume_m);
+		runtime->consume_cv.wait_for(
+			lock,
+			std::chrono::seconds(2),
+			[&] { return runtime->consumed >= expected; }
+		);
+	}
+	request_exit();
+}
+
+class PagefaultTest : public ::testing::Test
+{
+  protected:
+	const std::string TEST_ROOT = "/tmp/pagefault_test_dir";
+	const std::string TEST_LOG_FILE = TEST_ROOT + "/log.txt";
+	std::shared_ptr<PagefaultRuntime> runtime;
+
+	void SetUp() override
+	{
+		createTestFiles();
+		memset(g_test_events, 0, sizeof(g_test_events));
+		g_test_event_count = 0;
+	}
+
+	void TearDown() override
+	{
+		cleanTestFiles();
+	}
+
+	void createTestFiles()
+	{
+		mkdir(TEST_ROOT.c_str(), 0755);
+	}
+
+	void cleanTestFiles()
+	{
+		std::filesystem::remove_all(TEST_ROOT);
+	}
+
+	bool existStr(const std::string &str)
+	{
+		std::ifstream file(TEST_LOG_FILE, std::ios::binary | std::ios::ate);
+		if (!file.is_open())
+		{
+			return false;
+		}
+		std::streamsize size = file.tellg();
+		if (size <= 0)
+		{
+			return false;
+		}
+		file.seekg(0, std::ios::beg);
+		std::string content(size, '\0');
+		if (!file.read(&content[0], size))
+		{
+			return false;
+		}
+		return content.find(str) != std::string::npos;
+	}
+
+	void addTestEvent(
+		PagefaultTestEvent::EventType type,
+		pid_t pid,
+		pid_t tid,
+		const char *comm,
+		int stack_id,
+		__u64 timestamp,
+		unsigned long address,
+		unsigned long ip,
+		unsigned long error_code
+	)
+	{
+		ASSERT_LT(g_test_event_count, (size_t)TEST_EVENT_MAX);
+		PagefaultTestEvent &e = g_test_events[g_test_event_count++];
+		e.type = type;
+		e.event.pid = pid;
+		e.event.tid = tid;
+		e.event.stack_id = stack_id;
+		e.event.timestamp = timestamp;
+		e.event.address = address;
+		e.event.ip = ip;
+		e.event.error_code = error_code;
+		if (comm != nullptr)
+		{
+			strncpy(e.event.comm, comm, sizeof(e.event.comm) - 1);
+			e.event.comm[sizeof(e.event.comm) - 1] = '\0';
+		}
+		else
+		{
+			e.event.comm[0] = '\0';
+		}
+	}
+
+	void setTestEventStack(size_t idx, const std::vector<__u64> &user_ips)
+	{
+		ASSERT_LT(idx, g_test_event_count);
+		g_test_events[idx].has_stack = true;
+		g_test_events[idx].stack_ctx.user_ips = user_ips;
+	}
+
+	int runPagefault(const std::vector<std::string> &_args)
+	{
+		bool trace_user = false;
+		bool trace_kernel = false;
+		for (const auto &arg : _args)
+		{
+			if (arg == "-u" || arg == "--user")
+			{
+				trace_user = true;
+			}
+			if (arg == "-k" || arg == "--kernel")
+			{
+				trace_kernel = true;
+			}
+		}
+		if (!trace_user && !trace_kernel)
+		{
+			trace_user = true;
+			trace_kernel = true;
+		}
+		std::vector<std::string> t;
+		t.push_back("pagefault");
+		t.insert(t.end(), _args.begin(), _args.end());
+		std::vector<char *> argv;
+		argv.reserve(t.size());
+		for (const auto &arg : t)
+		{
+			argv.push_back(const_cast<char *>(arg.c_str()));
+		}
+		FILE *log_file = fopen(TEST_LOG_FILE.c_str(), "w");
+		if (!log_file)
+		{
+			ADD_FAILURE() << "Failed to create log file";
+			return -1;
+		}
+		runtime = pagefault_init(log_file);
+		std::future<PagefaultFds> fds_future = runtime->fds_promise.get_future();
+		std::thread event_thread(
+			event_worker,
+			g_test_events,
+			g_test_event_count,
+			trace_user,
+			trace_kernel,
+			runtime,
+			std::move(fds_future)
+		);
+		int ret = pagefault_main(argv.size(), argv.data());
+		{
+			std::lock_guard<std::mutex> lock(runtime->sync.m);
+			runtime->sync.exit_requested = true;
+		}
+		runtime->sync.cv.notify_all();
+		event_thread.join();
+		pagefault_deinit();
+		fclose(log_file);
+		return ret;
+	}
+};
+
+//SimpleTest1
+TEST_F(PagefaultTest, SimpleTest1)
+{
+	runPagefault({"-h"});
+	EXPECT_TRUE(existStr("Usage:"));
+}
+
+//测试能否正常输出
+TEST_F(PagefaultTest, SimpleTest2)
+{
+	addTestEvent(
+		PagefaultTestEvent::EVENT_USER,
+		582,
+		582,
+		"systemd-journal",
+		-1,
+		21591971226431ULL,
+		0x7fc5f4523b10UL,
+		0x7fc5f644c00cUL,
+		0x7UL
+	);
+	runPagefault({});
+	EXPECT_TRUE(
+		existStr(
+			"PID:582 TID:582 COMM:systemd-journal ADDR:0x7fc5f4523b10 "
+			"IP:0x7fc5f644c00c ERR:0x7"
+		)
+	);
+}
+
+//测试-p pid能否正常过滤
+TEST_F(PagefaultTest, PidFilterApplied)
+{
+	addTestEvent(PagefaultTestEvent::EVENT_KERNEL, 582, 582, "systemd-journal", -1, 1, 0x1000UL, 0x2000UL, 0x7UL);
+	addTestEvent(PagefaultTestEvent::EVENT_USER, 14922, 14922, "deepin-terminal", -1, 2, 0x3000UL, 0x4000UL, 0x6UL);
+	runPagefault({"-p", "14922"});
+	EXPECT_TRUE(!existStr("PID:582 TID:582 COMM:systemd-journal"));
+	EXPECT_TRUE(existStr("PID:14922 TID:14922 COMM:deepin-terminal"));
+}
+
+//测试-t timestamp能否正常输出
+TEST_F(PagefaultTest, TimestampOutputApplied)
+{
+	addTestEvent(PagefaultTestEvent::EVENT_KERNEL, 582, 582, "systemd-journal", -1, 21591971226431ULL, 0x1000UL, 0x2000UL, 0x7UL);
+	runPagefault({"-t"});
+	EXPECT_TRUE(existStr("TS:21591971226431"));
+}
+
+//测试-s stack能否正常输出
+TEST_F(PagefaultTest, StackOutputApplied)
+{
+	addTestEvent(PagefaultTestEvent::EVENT_USER, 14922, 14922, "deepin-terminal", 3, 10, 0x7f36ffaf0000UL, 0x7f3726d2243aUL, 0x6UL);
+	setTestEventStack(0, {0x1111ULL, 0x2222ULL, 0x3333ULL});
+	runPagefault({"-s"});
+	EXPECT_TRUE(existStr("User stack:"));
+	EXPECT_TRUE(existStr("0x1111"));
+	EXPECT_TRUE(existStr("0x2222"));
+	EXPECT_TRUE(existStr("0x3333"));
+}
+
+//测试-u user能否正常过滤
+TEST_F(PagefaultTest, UserFilterApplied)
+{
+	addTestEvent(PagefaultTestEvent::EVENT_KERNEL, 582, 582, "systemd-journal", -1, 1, 0x1000UL, 0x2000UL, 0x7UL);
+	addTestEvent(PagefaultTestEvent::EVENT_USER, 14922, 14922, "deepin-terminal", -1, 2, 0x3000UL, 0x4000UL, 0x6UL);
+	runPagefault({"-u"});
+	EXPECT_TRUE(!existStr("PID:582 TID:582 COMM:systemd-journal"));
+	EXPECT_TRUE(existStr("PID:14922 TID:14922 COMM:deepin-terminal"));
+}
+
+//测试-k kernel能否正常过滤
+TEST_F(PagefaultTest, KernelFilterApplied)
+{
+	addTestEvent(PagefaultTestEvent::EVENT_KERNEL, 582, 582, "systemd-journal", -1, 1, 0x1000UL, 0x2000UL, 0x7UL);
+	addTestEvent(PagefaultTestEvent::EVENT_USER, 14922, 14922, "deepin-terminal", -1, 2, 0x3000UL, 0x4000UL, 0x6UL);
+	runPagefault({"-k"});
+	EXPECT_TRUE(existStr("PID:582 TID:582 COMM:systemd-journal"));
+	EXPECT_TRUE(!existStr("PID:14922 TID:14922 COMM:deepin-terminal"));
+}
+
+//测试-p 非法参数能否正常报错
+TEST_F(PagefaultTest, InvalidPidRejected)
+{
+	EXPECT_EQ(runPagefault({"-p", "abc"}), -1);
+	EXPECT_TRUE(existStr("wrong pid value: abc, must be a positive integer"));
+}


### PR DESCRIPTION
### 对本次 pagefault 工具修改的内容

1. **补齐 BUILTIN 测试入口**

   - 改为通过返回值处理参数解析结果，增强健壮性。
2. **修复mock存在的问题，并且添加新功能**

- 在 test/mock-data-generator.h 新增了 MockStackCtx，提供 user_ips、kernel_ip，让单测可以给 mock 明确喂用户栈/内核栈
-  给 bpf_map 增加了 mmap_sz，方便区分“逻辑 map 大小”和实际 mmap 出来的大小，让ringbuf / shared mem 的释放和管理更准确
-  新增 recalc_map_storage()，统一根据 key_size/value_size/max_entries 重新计算 map->sz
- 修正以前 bpf_map__set_value_size() 直接改 sz 的错误行为，bpf_map__set_max_entries() 现在也会同步重算
-  新增 find_map_by_fd()，bpf_map_update_elem()、bpf_map_lookup_elem() 都改成走这个公共逻辑、
- 新增 stack trace mock 能力，新增fill_mock_stack_trace_from_values()、fill_mock_stack_trace()、bpf_get_stackid()这三个函数，让 mock 能真正支持 BPF_MAP_TYPE_STACK_TRACE
- 修正 bpf_map_get_info_by_fd()， 以前错误地把 info->max_entries 填成了 map->sz，现在返回真实的 key_size/value_size/max_entries
-  修正 bpf_object__open_skeleton()，ringbuf map 现在会正确设置 max_entries = RB_MAP_SIZE
